### PR TITLE
Add Support for BasePath and Host In Transformed Swagger

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
@@ -26,5 +26,10 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// The swagger endpoint config collection
         /// </summary>
         public List<SwaggerEndPointConfig> Config { get; set; }
+                
+        /// <summary>
+        /// This host url is use used to overwrite the host of the upstream service.
+        /// </summary>
+        public string HostOverride { get; set; }
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -60,7 +60,8 @@ namespace MMLib.SwaggerForOcelot.Middleware
             var httpClient = _httpClientFactory.CreateClient();
 
             var content = await httpClient.GetStringAsync(endPoint.Url);
-            content = _transformer.Transform(content, _reRoutes.Value.Where(p => p.SwaggerKey == endPoint.EndPoint.Key));
+            var hostName = endPoint.EndPoint.HostOverride ?? context.Request.Host.Value;
+            content = _transformer.Transform(content, _reRoutes.Value.Where(p => p.SwaggerKey == endPoint.EndPoint.Key), hostName);
 
             await context.Response.WriteAsync(content);
         }

--- a/src/MMLib.SwaggerForOcelot/SwaggerProperties.cs
+++ b/src/MMLib.SwaggerForOcelot/SwaggerProperties.cs
@@ -34,5 +34,10 @@
         /// The tag's name property name.
         /// </summary>
         public const string TagName = "name";
+        
+        /// <summary>
+        /// The Base Path
+        /// </summary>
+        public const string BasePath = "basePath";
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
@@ -15,9 +15,10 @@ namespace MMLib.SwaggerForOcelot.Transformation
         /// </summary>
         /// <param name="swaggerJson">The swagger json.</param>
         /// <param name="reRoutes">The re routes.</param>
+        /// <param name="hostOverride">The host override to add to swagger json.</param>
         /// <returns>
         /// Transformed swagger json.
         /// </returns>
-        string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes);
+        string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, string hostOverride);
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -14,16 +14,21 @@ namespace MMLib.SwaggerForOcelot.Transformation
     {
 
         /// <inheritdoc/>
-        public string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes)
+        public string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, string hostOverride)
         {
             JObject swagger = JObject.Parse(swaggerJson);
             var paths = swagger[SwaggerProperties.Paths];
-
+            var basePath = swagger.ContainsKey(SwaggerProperties.BasePath) ? swagger.GetValue(SwaggerProperties.BasePath).ToString() : "";
+            
             RemoveHost(swagger);
+            if (hostOverride != "")
+            {
+                AddHost(swagger, hostOverride);
+            }
 
             if (paths != null)
             {
-                RemovePaths(reRoutes, paths);
+                RemovePaths(reRoutes, paths, basePath);
 
                 RemoveItems<JProperty>(
                     swagger[SwaggerProperties.Definitions],
@@ -42,7 +47,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
             return swagger.ToString(Newtonsoft.Json.Formatting.Indented);
         }
 
-        private void RemovePaths(IEnumerable<ReRouteOptions> reRoutes, JToken paths)
+        private void RemovePaths(IEnumerable<ReRouteOptions> reRoutes, JToken paths, string basePath)
         {
             var forRemove = new List<JProperty>();
 
@@ -50,11 +55,11 @@ namespace MMLib.SwaggerForOcelot.Transformation
             {
                 var path = paths.ElementAt(i) as JProperty;
                 string downstreamPath = path.Name.RemoveSlashFromEnd();
-                var reRoute = FindReRoute(reRoutes, downstreamPath);
+                var reRoute = FindReRoute(reRoutes, downstreamPath, basePath);
 
                 if (reRoute != null && RemoveMethods(path, reRoute))
                 {
-                    RenameToken(path, ReplaceFirst(downstreamPath, reRoute.DownstreamPath, reRoute.UpstreamPath));
+                    RenameToken(path, ReplaceFirstInUrl(downstreamPath, reRoute.DownstreamPath, reRoute.UpstreamPath, basePath));
                 }
                 else
                 {
@@ -136,20 +141,35 @@ namespace MMLib.SwaggerForOcelot.Transformation
             }
         }
 
-        private static ReRouteOptions FindReRoute(IEnumerable<ReRouteOptions> reRoutes, string downstreamPath)
-            => reRoutes.FirstOrDefault(p
+        private static ReRouteOptions FindReRoute(IEnumerable<ReRouteOptions> reRoutes, string downstreamPath, string basePath)
+        {
+            var downstreamPathWithBasePath = basePath + downstreamPath;
+            return reRoutes.FirstOrDefault(p
                 => p.CanCatchAll
-                ? downstreamPath.StartsWith(p.DownstreamPath, StringComparison.CurrentCultureIgnoreCase)
-                : p.DownstreamPath.Equals(downstreamPath, StringComparison.CurrentCultureIgnoreCase));
+                    ? downstreamPathWithBasePath.StartsWith(p.DownstreamPath, StringComparison.CurrentCultureIgnoreCase)
+                    : p.DownstreamPath.Equals(downstreamPathWithBasePath, StringComparison.CurrentCultureIgnoreCase));
+        }
 
+        private static void AddHost(JObject swagger, string swaggerHost)
+        {
+            swagger.Add(SwaggerProperties.Host, swaggerHost);
+        }
+        
         private static void RemoveHost(JObject swagger)
         {
             swagger.Remove(SwaggerProperties.Host);
             swagger.Remove(SwaggerProperties.Schemes);
         }
 
-        private string ReplaceFirst(string text, string search, string replace)
+        private string ReplaceFirstInUrl(string text, string search, string replace, string basePath)
         {
+            //remove basePath from search and replace
+            if (basePath.Length > 0)
+            {
+                search = search.Replace(basePath, "");
+                replace = replace.Replace(basePath, "");
+            }
+            
             int pos = text.IndexOf(search, StringComparison.CurrentCultureIgnoreCase);
             if (pos < 0)
             {

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="Resources\SwaggerBase.json" />
     <None Remove="Resources\SwaggerBaseTransformed.json" />
@@ -17,7 +14,6 @@
     <None Remove="Resources\SwaggerPetsOnlyStore.json" />
     <None Remove="Resources\SwaggerPetsTransformed.json" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Resources\SwaggerNestedClassTransformed.json" />
     <EmbeddedResource Include="Resources\SwaggerNestedClass.json" />
@@ -36,13 +32,13 @@
     <EmbeddedResource Include="Resources\SwaggerPetsBase.json">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\SwaggerWithBasePathBase.json" />
+    <EmbeddedResource Include="Resources\SwaggerWithBasePathBaseTransformed.json" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Resources\SwaggerBase.json" />
     <EmbeddedResource Include="Resources\SwaggerBaseTransformed.json" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
@@ -53,13 +49,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\MMLib.SwaggerForOcelot\MMLib.SwaggerForOcelot.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-
 </Project>

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBase.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBase.json
@@ -4,19 +4,14 @@
     "version": "v1",
     "title": "Projects API"
   },
+  "basePath": "/api",
   "paths": {
-    "/api/projects/Projects": {
+    "/Projects": {
       "get": {
-        "tags": [
-          "Projects"
-        ],
+        "tags": [ "Projects" ],
         "operationId": "Get",
         "consumes": [],
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
+        "produces": [ "text/plain", "application/json", "text/json" ],
         "parameters": [],
         "responses": {
           "200": {
@@ -24,26 +19,18 @@
             "schema": {
               "uniqueItems": false,
               "type": "array",
-              "items": {
-                "$ref": "#/definitions/Project"
-              }
+              "items": { "$ref": "#/definitions/Project" }
             }
           }
         }
       }
     },
-    "/api/projects/Projects/{id}": {
+    "/Projects/{id}": {
       "get": {
-        "tags": [
-          "Projects"
-        ],
+        "tags": [ "Projects" ],
         "operationId": "Get",
         "consumes": [],
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
+        "produces": [ "text/plain", "application/json", "text/json" ],
         "parameters": [
           {
             "name": "id",
@@ -56,61 +43,38 @@
         "responses": {
           "200": {
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/Project"
-            }
+            "schema": { "$ref": "#/definitions/Project" }
           },
-          "404": {
-            "description": "Not Found"
-          }
+          "404": { "description": "Not Found" }
         }
       }
     },
-    "/api/projects/Projects/projectCreate": {
+    "/Projects/projectCreate": {
       "post": {
-        "tags": [
-          "Projects"
-        ],
+        "tags": [ "Projects" ],
         "operationId": "CreateProject",
-        "consumes": [
-          "application/json-patch+json",
-          "application/json",
-          "text/json",
-          "application/*+json"
-        ],
+        "consumes": [ "application/json-patch+json", "application/json", "text/json", "application/*+json" ],
         "produces": [],
         "parameters": [
           {
             "name": "projectViewModel",
             "in": "body",
             "required": false,
-            "schema": {
-              "$ref": "#/definitions/ProjectViewModel"
-            }
+            "schema": { "$ref": "#/definitions/ProjectViewModel" }
           }
         ],
         "responses": {
-          "201": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Bad Request"
-          }
+          "201": { "description": "Success" },
+          "400": { "description": "Bad Request" }
         }
       }
     },
-    "/api/projects/Values": {
+    "/Values": {
       "get": {
-        "tags": [
-          "Values"
-        ],
+        "tags": [ "Values" ],
         "operationId": "Get",
         "consumes": [],
-        "produces": [
-          "text/plain",
-          "application/json",
-          "text/json"
-        ],
+        "produces": [ "text/plain", "application/json", "text/json" ],
         "parameters": [],
         "responses": {
           "200": {
@@ -118,9 +82,7 @@
             "schema": {
               "uniqueItems": false,
               "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "items": { "type": "string" }
             }
           }
         }
@@ -135,22 +97,13 @@
           "format": "int32",
           "type": "integer"
         },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "owner": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "owner": { "type": "string" }
       }
     },
     "ProjectViewModel": {
-      "required": [
-        "name",
-        "owner"
-      ],
+      "required": [ "name", "owner" ],
       "type": "object",
       "properties": {
         "name": {
@@ -161,11 +114,8 @@
           "maxLength": 255,
           "type": "string"
         },
-        "owner": {
-          "type": "string"
-        }
+        "owner": { "type": "string" }
       }
     }
-  },
-  "host": "localhost:8000"
+  }
 }

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBaseTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBaseTransformed.json
@@ -4,8 +4,9 @@
     "version": "v1",
     "title": "Projects API"
   },
+  "basePath": "/api",
   "paths": {
-    "/api/projects/Projects": {
+    "/projects/Projects": {
       "get": {
         "tags": [
           "Projects"
@@ -32,7 +33,7 @@
         }
       }
     },
-    "/api/projects/Projects/{id}": {
+    "/projects/Projects/{id}": {
       "get": {
         "tags": [
           "Projects"
@@ -66,7 +67,7 @@
         }
       }
     },
-    "/api/projects/Projects/projectCreate": {
+    "/projects/Projects/projectCreate": {
       "post": {
         "tags": [
           "Projects"
@@ -99,7 +100,7 @@
         }
       }
     },
-    "/api/projects/Values": {
+    "/projects/Values": {
       "get": {
         "tags": [
           "Values"
@@ -166,6 +167,5 @@
         }
       }
     }
-  },
-  "host": "localhost:8000"
+  }
 }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerJsonFormatterShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerJsonFormatterShould.cs
@@ -21,7 +21,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                     DownstreamPathTemplate ="/api/{everything}"}
             };
 
-            await TransformAndCheck(reroutes, "SwaggerBase", "SwaggerBaseTransformed");
+            await TransformAndCheck(reroutes, "SwaggerBase", "SwaggerBaseTransformed", "localhost:8000");
         }
 
         [Fact]
@@ -36,7 +36,21 @@ namespace MMLib.SwaggerForOcelot.Tests
                     DownstreamPathTemplate ="/project/api/{everything}"}
             };
 
-            await TransformAndCheck(reroutes, "SwaggerBase", "SwaggerBaseTransformed");
+            await TransformAndCheck(reroutes, "SwaggerBase", "SwaggerBaseTransformed", "localhost:8000");
+        }
+        
+        [Fact]
+        public async Task CreateNewJsonWithBasePath()
+        {
+            var reroutes = new List<ReRouteOptions>()
+            {
+                new ReRouteOptions(){
+                    SwaggerKey = "projects",
+                    UpstreamPathTemplate ="/api/projects/{everything}",
+                    DownstreamPathTemplate ="/api/{everything}"}
+            };
+
+            await TransformAndCheck(reroutes, "SwaggerWithBasePathBase", "SwaggerWithBasePathBaseTransformed");
         }
 
         [Fact]
@@ -46,8 +60,8 @@ namespace MMLib.SwaggerForOcelot.Tests
             {
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/store/{everything}",
-                    DownstreamPathTemplate ="/store/{everything}"}
+                    UpstreamPathTemplate ="/v2/api/store/{everything}",
+                    DownstreamPathTemplate ="/v2/store/{everything}"}
             };
 
             await TransformAndCheck(reroutes, "SwaggerPetsBase", "SwaggerPetsOnlyStore");
@@ -60,16 +74,16 @@ namespace MMLib.SwaggerForOcelot.Tests
             {
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/pets/pet/{everything}",
-                    DownstreamPathTemplate ="/pet/{everything}"},
+                    UpstreamPathTemplate ="/v2/api/pets/pet/{everything}",
+                    DownstreamPathTemplate ="/v2/pet/{everything}"},
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/pets/store/{everything}",
-                    DownstreamPathTemplate ="/store/{everything}"},
+                    UpstreamPathTemplate ="/v2/api/pets/store/{everything}",
+                    DownstreamPathTemplate ="/v2/store/{everything}"},
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/pets/user/{everything}",
-                    DownstreamPathTemplate ="/user/{everything}"}
+                    UpstreamPathTemplate ="/v2/api/pets/user/{everything}",
+                    DownstreamPathTemplate ="/v2/user/{everything}"}
             };
 
             await TransformAndCheck(reroutes, "SwaggerPetsBase", "SwaggerPetsTransformed");
@@ -82,22 +96,22 @@ namespace MMLib.SwaggerForOcelot.Tests
             {
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/pets/pet/findByStatus",
-                    DownstreamPathTemplate ="/pet/findByStatus",
+                    UpstreamPathTemplate ="/v2/api/pets/pet/findByStatus",
+                    DownstreamPathTemplate ="/v2/pet/findByStatus",
                     UpstreamHttpMethod = new HashSet<string>(){ "Get"} },
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/pets/pet/{petId}",
-                    DownstreamPathTemplate ="/pet/{petId}",
+                    UpstreamPathTemplate ="/v2/api/pets/pet/{petId}",
+                    DownstreamPathTemplate ="/v2/pet/{petId}",
                     UpstreamHttpMethod = new HashSet<string>(){ "Post"} },
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/pets/store/{everything}",
-                    DownstreamPathTemplate ="/store/{everything}"},
+                    UpstreamPathTemplate ="/v2/api/pets/store/{everything}",
+                    DownstreamPathTemplate ="/v2/store/{everything}"},
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/pets/user/{everything}",
-                    DownstreamPathTemplate ="/user/{everything}"}
+                    UpstreamPathTemplate ="/v2/api/pets/user/{everything}",
+                    DownstreamPathTemplate ="/v2/user/{everything}"}
             };
 
             await TransformAndCheck(reroutes, "SwaggerPetsBase", "SwaggerPetsOnlyAnyActions");
@@ -110,8 +124,8 @@ namespace MMLib.SwaggerForOcelot.Tests
             {
                 new ReRouteOptions(){
                     SwaggerKey = "pets",
-                    UpstreamPathTemplate ="/api/pets/{everything}",
-                    DownstreamPathTemplate ="/{everything}",
+                    UpstreamPathTemplate ="/v2/api/pets/{everything}",
+                    DownstreamPathTemplate ="/v2/{everything}",
                     UpstreamHttpMethod = new List<string>(){ "POST" }
                 }
             };
@@ -138,12 +152,13 @@ namespace MMLib.SwaggerForOcelot.Tests
         private async Task TransformAndCheck(
             IEnumerable<ReRouteOptions> reroutes,
             string swaggerBaseFileName,
-            string expectedSwaggerFileName)
+            string expectedSwaggerFileName,
+            string basePath = "")
         {
             var transformer = new SwaggerJsonTransformer();
             string swaggerBase = await GetBaseSwagger(swaggerBaseFileName);
 
-            var transfomed = transformer.Transform(swaggerBase, reroutes);
+            var transfomed = transformer.Transform(swaggerBase, reroutes, basePath);
 
             await AreEquel(transfomed, expectedSwaggerFileName);
         }


### PR DESCRIPTION
Add the ability to override the swagger host or to have it found by default
Add support for swagger with basePath
BasePaths are now properly found in the reroute as long as the basePath is in the downstream/updatestream Path Templates
Update test to check for host and basePath support

PR to solve #21 

