### PR TITLE
Different configuration for ocelot swagger generator endpoint and downstreat service

### DIFF
--- a/MMLib.SwaggerForOcelot.sln
+++ b/MMLib.SwaggerForOcelot.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PetstoreService", "demo\Pet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrderService", "demo\OrderService\OrderService.csproj", "{F823FFA3-F5D9-488E-ADAB-15C4E9790DC5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiGatewayWithPath", "demo\ApiGatewayWithPath\ApiGatewayWithPath.csproj", "{DF18713F-3BE4-4300-BB41-D8239AAC2CA4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{F823FFA3-F5D9-488E-ADAB-15C4E9790DC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F823FFA3-F5D9-488E-ADAB-15C4E9790DC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F823FFA3-F5D9-488E-ADAB-15C4E9790DC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF18713F-3BE4-4300-BB41-D8239AAC2CA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF18713F-3BE4-4300-BB41-D8239AAC2CA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF18713F-3BE4-4300-BB41-D8239AAC2CA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF18713F-3BE4-4300-BB41-D8239AAC2CA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -69,6 +75,7 @@ Global
 		{D66F3C86-8D57-4802-B2F9-15F91262F12D} = {A9111054-B663-41BA-AE67-E6FE3E7515AF}
 		{0C20742E-0D4E-4407-AC5B-4162EEBD8FC5} = {75938D16-D280-4200-A970-8D33B719D252}
 		{F823FFA3-F5D9-488E-ADAB-15C4E9790DC5} = {75938D16-D280-4200-A970-8D33B719D252}
+		{DF18713F-3BE4-4300-BB41-D8239AAC2CA4} = {75938D16-D280-4200-A970-8D33B719D252}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AAA408E9-E738-4F2B-A6C2-B35AAADDB00F}

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Direct via `http://ocelotprojecturl:port/swagger` provides documentation for dow
 5. In `Configure` method, insert the `SwaggerForOcelot` middleware to expose interactive documentation.
    ```CSharp
           app.UseSwaggerForOcelotUI(Configuration, opt => {
-                opt.EndPointBasePath = "/swagger/docs";
+                opt.PathToSwaggerGenerator = "/swagger/docs";
             })
    ```
 6. Show your microservices interactive documentation.

--- a/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
+++ b/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Ocelot" Version="12.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MMLib.SwaggerForOcelot\MMLib.SwaggerForOcelot.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/demo/ApiGatewayWithPath/Program.cs
+++ b/demo/ApiGatewayWithPath/Program.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace ApiGatewayWithPath
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    config
+                        .SetBasePath(hostingContext.HostingEnvironment.ContentRootPath)
+                        .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                        .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json",
+                            optional: true, reloadOnChange: true)
+                        .AddJsonFile($"appsettings.local.json", optional: true, reloadOnChange: true)
+                        .AddJsonFile("ocelot.json")
+                        .AddEnvironmentVariables();
+                })
+                .UseStartup<Startup>();
+    }
+}

--- a/demo/ApiGatewayWithPath/Startup.cs
+++ b/demo/ApiGatewayWithPath/Startup.cs
@@ -10,7 +10,6 @@ namespace ApiGatewayWithPath
 {
     public class Startup
     {
-
         private readonly IHostingEnvironment _env;
         public Startup(IHostingEnvironment env, IConfiguration config)
         {

--- a/demo/ApiGatewayWithPath/Startup.cs
+++ b/demo/ApiGatewayWithPath/Startup.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Ocelot.DependencyInjection;
+using Ocelot.Middleware;
+
+namespace ApiGatewayWithPath
+{
+    public class Startup
+    {
+
+        private readonly IHostingEnvironment _env;
+        public Startup(IHostingEnvironment env, IConfiguration config)
+        {
+            _env = env;
+            Configuration = config;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddOcelot();
+            services.AddSwaggerForOcelot(Configuration);
+
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UsePathBase("/gateway");
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            app.UseStaticFiles();
+            app.UseSwaggerForOcelotUI(Configuration, opt => {
+                opt.DownstreamSwaggerEndPointBasePath = "/gateway/swagger/docs";
+                opt.PathToSwaggerGenerator= "/swagger/docs";
+            })
+            .UseOcelot()
+            .Wait();
+        }
+    }
+}

--- a/demo/ApiGatewayWithPath/appsettings.Development.json
+++ b/demo/ApiGatewayWithPath/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/demo/ApiGatewayWithPath/appsettings.json
+++ b/demo/ApiGatewayWithPath/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/demo/ApiGatewayWithPath/ocelot.json
+++ b/demo/ApiGatewayWithPath/ocelot.json
@@ -1,0 +1,115 @@
+{
+  "ReRoutes": [
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 5100
+        }
+      ],
+      "UpstreamPathTemplate": "/api/contacts/{everything}",
+      "UpstreamHttpMethod": [ "Get" ],
+      "SwaggerKey": "contacts"
+    },
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 5200
+        }
+      ],
+      "UpstreamPathTemplate": "/api/projects/{everything}",
+      "SwaggerKey": "projects"
+    },
+    {
+      "DownstreamPathTemplate": "/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 5300
+        }
+      ],
+      "UpstreamHttpMethod": [ "Get", "Post" ],
+      "UpstreamPathTemplate": "/api/pets/{everything}",
+      "SwaggerKey": "pets"
+    },
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 5400
+        }
+      ],
+      "UpstreamPathTemplate": "/api/orders/{everything}",
+      "UpstreamHttpMethod": [],
+      "SwaggerKey": "orders"
+    }
+  ],
+  "SwaggerEndPoints": [
+    {
+      "Key": "contacts",
+      "Config": [
+        {
+          "Name": "Contacts API",
+          "Version": "v1",
+          "Url": "http://localhost:5000/swagger/v1/swagger.json"
+        }
+      ]
+    },
+    {
+      "Key": "projects",
+      "Config": [
+        {
+          "Name": "Projects API",
+          "Version": "v1",
+          "Url": "http://localhost:5200/swagger/v1/swagger.json"
+        }
+      ]
+    },
+    {
+      "Key": "pets",
+      "Config": [
+        {
+          "Name": "Pets API",
+          "Version": "v1",
+          "Url": "http://localhost:5300/swagger.json"
+        }
+      ]
+    },
+    {
+      "Key": "orders",
+      "Config": [
+        {
+          "Name": "Orders API",
+          "Version": "v0.9",
+          "Url": "http://localhost:5400/swagger/v0.9/swagger.json"
+        },
+        {
+          "Name": "Orders API",
+          "Version": "v1",
+          "Url": "http://localhost:5400/swagger/v1/swagger.json"
+        },
+        {
+          "Name": "Orders API",
+          "Version": "v2",
+          "Url": "http://localhost:5400/swagger/v2/swagger.json"
+        },
+        {
+          "Name": "Orders API",
+          "Version": "v3",
+          "Url": "http://localhost:5400/swagger/v3/swagger.json"
+        }
+      ]
+    }
+  ],
+  "GlobalConfiguration": {
+    "BaseUrl": "http://localhost"
+  }
+}

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
@@ -26,7 +26,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// The swagger endpoint config collection
         /// </summary>
         public List<SwaggerEndPointConfig> Config { get; set; }
-                
+
         /// <summary>
         /// This host url is use used to overwrite the host of the upstream service.
         /// </summary>

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Swashbuckle.AspNetCore.SwaggerUI;
+using System;
 
 namespace MMLib.SwaggerForOcelot.Configuration
 {
@@ -6,12 +7,30 @@ namespace MMLib.SwaggerForOcelot.Configuration
     /// Configuration for Swagger UI.
     /// </summary>
     /// <seealso cref="Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIOptions" />
-    public class SwaggerForOcelotUIOptions: SwaggerUIOptions
+    public class SwaggerForOcelotUIOptions : SwaggerUIOptions
     {
+        private string _pathToSwaggerUI = "/swagger/docs";
+
         /// <summary>
-        /// The end point base path. The final path to swagger endpoint is
-        /// <see cref="EndPointBasePath"/> + <see cref="SwaggerEndPointOptions.Key"/>
+        /// The relative path to gateway swagger generator.
         /// </summary>
-        public string EndPointBasePath { get; set; } = "/swagger/docs";
+        public string PathToSwaggerGenerator
+        {
+            get => !string.IsNullOrWhiteSpace(EndPointBasePath) ? EndPointBasePath : _pathToSwaggerUI;
+            set => _pathToSwaggerUI = value;
+        }
+
+        /// <summary>
+        /// The base path to ocelot gateway swagger UI.
+        /// </summary>
+        [Obsolete("Use the 'PathToSwaggerUI' property.")]
+        public string EndPointBasePath { get; set; }
+
+        /// <summary>
+        /// The base path to downstream service api swagger generator endpoint.
+        /// Final path is:
+        /// <see cref="EndPointBasePath"/> + <see cref="SwaggerEndPointConfig.Version"/> + <see cref="SwaggerEndPointOptions.Key"/>
+        /// </summary>
+        public string DownstreamSwaggerEndPointBasePath { get; set; } = "/swagger/docs";
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Middleware/BuilderExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/BuilderExtensions.cs
@@ -47,14 +47,14 @@ namespace Microsoft.AspNetCore.Builder
             {
                 InitUIOption(c, options);
                 var endPoints = GetConfiguration(configuration);
-                AddSwaggerEndPoints(c, endPoints, options.EndPointBasePath);
+                AddSwaggerEndPoints(c, endPoints, options.DownstreamSwaggerEndPointBasePath);
             });
 
             return app;
         }
 
         private static void UseSwaggerForOcelot(IApplicationBuilder app, SwaggerForOcelotUIOptions options)
-            => app.Map(options.EndPointBasePath, builder => builder.UseMiddleware<SwaggerForOcelotMiddleware>(options));
+            => app.Map(options.PathToSwaggerGenerator, builder => builder.UseMiddleware<SwaggerForOcelotMiddleware>(options));
 
         private static void AddSwaggerEndPoints(SwaggerUIOptions c, IEnumerable<SwaggerEndPointOptions> endPoints, string basePath)
         {
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Builder
                 foreach (var config in endPoint.Config)
                 {
                     c.SwaggerEndpoint($"{basePath}/{config.Version}/{endPoint.KeyToPath}", $"{config.Name} - {config.Version}");
-                }     
+                }
             }
         }
 


### PR DESCRIPTION
This PR implement issue #27.

New configuration property was added: `DownstreamSwaggerEndPointBasePath`.
This property sets the base path for getting swagger documentation of downstream services. Default is `/swagger/docs` (preserving compatibility).

Final path is: `{DownstreamSwaggerEndPointBasePath}/{Version}/{KeyToPath}`.

Property `EndPointBasePath` was marked as `Obsolete` (Because of ambiguous opinion). 
The property `PathToSwaggerGenerator` has been added instead.


