### PR TITLE
Fixed: Incorrect contacting of the resulting path when the base path

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -1,3 +1,4 @@
+using Kros.IO;
 using MMLib.SwaggerForOcelot.Configuration;
 using Newtonsoft.Json.Linq;
 using System;
@@ -21,6 +22,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
             var basePath = swagger.ContainsKey(SwaggerProperties.BasePath)
                 ? swagger.GetValue(SwaggerProperties.BasePath).ToString()
                 : "";
+            basePath = basePath.TrimEnd('/');
 
             RemoveHost(swagger);
             if (hostOverride != "")
@@ -145,7 +147,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
 
         private static ReRouteOptions FindReRoute(IEnumerable<ReRouteOptions> reRoutes, string downstreamPath, string basePath)
         {
-            var downstreamPathWithBasePath = basePath + downstreamPath;
+            var downstreamPathWithBasePath = PathHelper.BuildPath(basePath, downstreamPath);
             return reRoutes.FirstOrDefault(p
                 => p.CanCatchAll
                     ? downstreamPathWithBasePath.StartsWith(p.DownstreamPath, StringComparison.CurrentCultureIgnoreCase)

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerBase.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerBase.json
@@ -4,6 +4,7 @@
     "version": "v1",
     "title": "Projects API"
   },
+  "basePath": "/",
   "paths": {
     "/api/Projects": {
       "get": {

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerBaseTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerBaseTransformed.json
@@ -4,6 +4,7 @@
     "version": "v1",
     "title": "Projects API"
   },
+  "basePath": "/",
   "paths": {
     "/api/projects/Projects": {
       "get": {

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBase.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBase.json
@@ -4,7 +4,7 @@
     "version": "v1",
     "title": "Projects API"
   },
-  "basePath": "/api",
+  "basePath": "/api/",
   "paths": {
     "/Projects": {
       "get": {

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBaseTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBaseTransformed.json
@@ -4,7 +4,7 @@
     "version": "v1",
     "title": "Projects API"
   },
-  "basePath": "/api",
+  "basePath": "/api/",
   "paths": {
     "/projects/Projects": {
       "get": {


### PR DESCRIPTION
Incorrect contacting of the resulting path when the base route contained `/` at the end.