### PR TITLE
	modified:   src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTra…

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -46,24 +46,24 @@ namespace MMLib.SwaggerForOcelot.Transformation
                 AddHost(swagger, hostOverride);
             }
 
-            if (paths != null)
-            {
-                RemovePaths(reRoutes, paths, basePath);
+            //if (paths != null)
+            //{
+            //    RemovePaths(reRoutes, paths, basePath);
 
-                RemoveItems<JProperty>(
-                    swagger[SwaggerProperties.Definitions],
-                    paths,
-                    i => $"$..[?(@*.$ref == '#/{SwaggerProperties.Definitions}/{i.Name}')]",
-                    i => $"$..[?(@*.*.items.$ref == '#/{SwaggerProperties.Definitions}/{i.Name}')]",
-                    i => $"$..[?(@*.*.allOf[?(@.$ref == '#/{SwaggerProperties.Definitions}/{i.Name}')])]");
-                if (swagger["tags"] != null)
-                {
-                    RemoveItems<JObject>(
-                        swagger[SwaggerProperties.Tags],
-                        paths,
-                        i => $"$..tags[?(@ == '{i[SwaggerProperties.TagName]}')]");
-                }
-            }
+            //    RemoveItems<JProperty>(
+            //        swagger[SwaggerProperties.Definitions],
+            //        paths,
+            //        i => $"$..[?(@*.$ref == '#/{SwaggerProperties.Definitions}/{i.Name}')]",
+            //        i => $"$..[?(@*.*.items.$ref == '#/{SwaggerProperties.Definitions}/{i.Name}')]",
+            //        i => $"$..[?(@*.*.allOf[?(@.$ref == '#/{SwaggerProperties.Definitions}/{i.Name}')])]");
+            //    if (swagger["tags"] != null)
+            //    {
+            //        RemoveItems<JObject>(
+            //            swagger[SwaggerProperties.Tags],
+            //            paths,
+            //            i => $"$..tags[?(@ == '{i[SwaggerProperties.TagName]}')]");
+            //    }
+            //}
 
             return swagger.ToString(Formatting.Indented);
         }


### PR DESCRIPTION
…nsformer.cs

Not sure why this part is added but it solves issue #19 by @nkovacic (All paths and definitions are removed from swagger.json)
as far as I can see.
I'll get further in to this when I have more time but for now on, people that experience the same problem could use this patch
for now.


