### PR TITLE
fix path generation when using a host override and upstream/downstrea…

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -88,7 +88,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
             if (openApi.ContainsKey(OpenApiProperties.Servers))
             {
                 var firstUrl = openApi.GetValue(OpenApiProperties.Servers).First.Value<string>(OpenApiProperties.Url);
-                basePath = hostOverride.Length > 0 ? new Uri(firstUrl).AbsolutePath : firstUrl;
+                basePath = hostOverride.Length > 0 ? new Uri(firstUrl).AbsolutePath.RemoveSlashFromEnd() : firstUrl;
             }
 
             if (paths != null)

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -49,6 +49,9 @@
     <EmbeddedResource Include="Resources\SwaggerWithBasePathBaseTransformed.json" />
     <EmbeddedResource Include="Resources\OpenApiWithServersBase.json" />
     <EmbeddedResource Include="Resources\OpenApiWithServersBaseTransformed.json" />
+    <EmbeddedResource Include="Resources\OpenApiWithHostOverrideAndDifferentUpstreamAndDownstreamPathsBase.json" />
+    <EmbeddedResource Include="Resources\OpenApiWithHostOverrideAndDifferentUpstreamAndDownstreamPathsBaseTransformed.json" />
+
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\SwaggerBase.json" />

--- a/tests/MMLib.SwaggerForOcelot.Tests/OpenApiJsonFormatterShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/OpenApiJsonFormatterShould.cs
@@ -73,6 +73,26 @@ namespace MMLib.SwaggerForOcelot.Tests
             await TransformAndCheck(reroutes, "OpenApiWithServersBase", "OpenApiWithHostOverrideBaseTransformed", "http://override.host.it");
         }
 
+        [Fact]
+        public async Task CreateNewJsonWithHostOverrideWhenUpstreamAndDownstreamPathsAreDifferent()
+        {
+            var reroutes = new List<ReRouteOptions>
+            {
+                new ReRouteOptions
+                {
+                    SwaggerKey = "projects",
+                    UpstreamPathTemplate = "/prefix/api/projects/{everything}",
+                    DownstreamPathTemplate = "/api/{everything}"
+                }
+            };
+
+            await TransformAndCheck(
+                reroutes,
+                "OpenApiWithHostOverrideAndDifferentUpstreamAndDownstreamPathsBase",
+                "OpenApiWithHostOverrideAndDifferentUpstreamAndDownstreamPathsBaseTransformed",
+                "http://service.api.io");
+        }
+
         private async Task TransformAndCheck(
             IEnumerable<ReRouteOptions> reroutes,
             string openApiBaseFileName,

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithHostOverrideAndDifferentUpstreamAndDownstreamPathsBase.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithHostOverrideAndDifferentUpstreamAndDownstreamPathsBase.json
@@ -1,0 +1,175 @@
+{
+  "openapi": "3.0",
+  "info": {
+    "version": "v1",
+    "title": "Projects API"
+  },
+  "servers": [{
+    "url": ""
+  }],
+  "paths": {
+    "/api/Projects": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "Get",
+        "consumes": [],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "uniqueItems": false,
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Project"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Projects/{id}": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "Get",
+        "consumes": [],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/components/schemas/Project"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/Projects/projectCreate": {
+      "post": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "CreateProject",
+        "consumes": [
+          "application/json-patch+json",
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "projectViewModel",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ProjectViewModel"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/Values": {
+      "get": {
+        "tags": [
+          "Values"
+        ],
+        "operationId": "Get",
+        "consumes": [],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "uniqueItems": false,
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Project": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      },
+      "ProjectViewModel": {
+        "required": [
+          "name",
+          "owner"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "description": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithHostOverrideAndDifferentUpstreamAndDownstreamPathsBaseTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithHostOverrideAndDifferentUpstreamAndDownstreamPathsBaseTransformed.json
@@ -1,0 +1,175 @@
+{
+  "openapi": "3.0",
+  "info": {
+    "version": "v1",
+    "title": "Projects API"
+  },
+  "servers": [{
+    "url": "http://service.api.io"
+  }],
+  "paths": {
+    "/prefix/api/projects/Projects": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "Get",
+        "consumes": [],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "uniqueItems": false,
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Project"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prefix/api/projects/Projects/{id}": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "Get",
+        "consumes": [],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/components/schemas/Project"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/prefix/api/projects/Projects/projectCreate": {
+      "post": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "CreateProject",
+        "consumes": [
+          "application/json-patch+json",
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "projectViewModel",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ProjectViewModel"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/prefix/api/projects/Values": {
+      "get": {
+        "tags": [
+          "Values"
+        ],
+        "operationId": "Get",
+        "consumes": [],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "uniqueItems": false,
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Project": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      },
+      "ProjectViewModel": {
+        "required": [
+          "name",
+          "owner"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "description": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hello,

This PR fixes a bug that is present in the `OpenApi` transformer when using a `hostOverride` and when the upstream/downstream paths are different. 
Ex.
`UpstreamPathTemplate= "api/project"`
`DownstreamPathTemplate= "project"`
The transformer will transform the downstream path to  `/apiproject`.
