### PR TITLE
Remove downstream basepath from upstream basepath

### DIFF
--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithHostOverrideBaseTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithHostOverrideBaseTransformed.json
@@ -6,17 +6,11 @@
   },
   "servers": [
     {
-      "url": "http://override.host.it/api"
-    },
-    {
-      "url": "http://override.host.it/"
-    },
-    {
-      "url": "http://override.host.it/api2"
+      "url": "http://override.host.it"
     }
   ],
   "paths": {
-    "/projects/Projects": {
+    "/api/projects/Projects": {
       "get": {
         "tags": [
           "Projects"
@@ -43,7 +37,7 @@
         }
       }
     },
-    "/projects/Projects/{id}": {
+    "/api/projects/Projects/{id}": {
       "get": {
         "tags": [
           "Projects"
@@ -77,7 +71,7 @@
         }
       }
     },
-    "/projects/Projects/projectCreate": {
+    "/api/projects/Projects/projectCreate": {
       "post": {
         "tags": [
           "Projects"
@@ -110,7 +104,7 @@
         }
       }
     },
-    "/projects/Values": {
+    "/api/projects/Values": {
       "get": {
         "tags": [
           "Values"

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithServersBase.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithServersBase.json
@@ -7,12 +7,6 @@
   "servers": [
     {
       "url": "http://test.it/api"
-    },
-    {
-      "url": "http://dev.test.it"
-    },
-    {
-      "url": "/api2"
     }
   ],
   "paths": {

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithServersBaseTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithServersBaseTransformed.json
@@ -6,17 +6,11 @@
   },
   "servers": [
     {
-      "url": "/api"
-    },
-    {
-      "url": "/"
-    },
-    {
-      "url": "/api2"
+      "url": ""
     }
   ],
   "paths": {
-    "/projects/Projects": {
+    "/api/projects/Projects": {
       "get": {
         "tags": [
           "Projects"
@@ -43,7 +37,7 @@
         }
       }
     },
-    "/projects/Projects/{id}": {
+    "/api/projects/Projects/{id}": {
       "get": {
         "tags": [
           "Projects"
@@ -77,7 +71,7 @@
         }
       }
     },
-    "/projects/Projects/projectCreate": {
+    "/api/projects/Projects/projectCreate": {
       "post": {
         "tags": [
           "Projects"
@@ -110,7 +104,7 @@
         }
       }
     },
-    "/projects/Values": {
+    "/api/projects/Values": {
       "get": {
         "tags": [
           "Values"

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerPetsOnlyAnyActions.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerPetsOnlyAnyActions.json
@@ -11,7 +11,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
-  "basePath": "/v2",
+  "basePath": "/",
   "tags": [
     {
       "name": "pet",
@@ -35,7 +35,7 @@
     }
   ],
   "paths": {
-    "/api/pets/pet/findByStatus": {
+    "/v2/api/pets/pet/findByStatus": {
       "get": {
         "tags": [ "pet" ],
         "summary": "Finds Pets by status",
@@ -70,7 +70,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/pet/{petId}": {
+    "/v2/api/pets/pet/{petId}": {
       "post": {
         "tags": [ "pet" ],
         "summary": "Updates a pet in the store with form data",
@@ -106,7 +106,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/store/inventory": {
+    "/v2/api/pets/store/inventory": {
       "get": {
         "tags": [ "store" ],
         "summary": "Returns pet inventories by status",
@@ -129,7 +129,7 @@
         "security": [ { "api_key": [] } ]
       }
     },
-    "/api/pets/store/order": {
+    "/v2/api/pets/store/order": {
       "post": {
         "tags": [ "store" ],
         "summary": "Place an order for a pet",
@@ -154,7 +154,7 @@
         }
       }
     },
-    "/api/pets/store/order/{orderId}": {
+    "/v2/api/pets/store/order/{orderId}": {
       "get": {
         "tags": [ "store" ],
         "summary": "Find purchase order by ID",
@@ -205,7 +205,7 @@
         }
       }
     },
-    "/api/pets/user": {
+    "/v2/api/pets/user": {
       "post": {
         "tags": [ "user" ],
         "summary": "Create user",
@@ -224,7 +224,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/createWithArray": {
+    "/v2/api/pets/user/createWithArray": {
       "post": {
         "tags": [ "user" ],
         "summary": "Creates list of users with given input array",
@@ -246,7 +246,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/createWithList": {
+    "/v2/api/pets/user/createWithList": {
       "post": {
         "tags": [ "user" ],
         "summary": "Creates list of users with given input array",
@@ -268,7 +268,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/login": {
+    "/v2/api/pets/user/login": {
       "get": {
         "tags": [ "user" ],
         "summary": "Logs user into the system",
@@ -312,7 +312,7 @@
         }
       }
     },
-    "/api/pets/user/logout": {
+    "/v2/api/pets/user/logout": {
       "get": {
         "tags": [ "user" ],
         "summary": "Logs out current logged in user session",
@@ -323,7 +323,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/{username}": {
+    "/v2/api/pets/user/{username}": {
       "get": {
         "tags": [ "user" ],
         "summary": "Get user by user name",

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerPetsOnlyPost.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerPetsOnlyPost.json
@@ -11,7 +11,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
-  "basePath": "/v2",
+  "basePath": "/",
   "tags": [
     {
       "name": "pet",
@@ -35,7 +35,7 @@
     }
   ],
   "paths": {
-    "/api/pets/pet": {
+    "/v2/api/pets/pet": {
       "post": {
         "tags": [ "pet" ],
         "summary": "Add a new pet to the store",
@@ -56,7 +56,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/pet/{petId}": {
+    "/v2/api/pets/pet/{petId}": {
       "post": {
         "tags": [ "pet" ],
         "summary": "Updates a pet in the store with form data",
@@ -92,7 +92,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/pet/{petId}/uploadImage": {
+    "/v2/api/pets/pet/{petId}/uploadImage": {
       "post": {
         "tags": [ "pet" ],
         "summary": "uploads an image",
@@ -133,7 +133,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/store/order": {
+    "/v2/api/pets/store/order": {
       "post": {
         "tags": [ "store" ],
         "summary": "Place an order for a pet",
@@ -158,7 +158,7 @@
         }
       }
     },
-    "/api/pets/user": {
+    "/v2/api/pets/user": {
       "post": {
         "tags": [ "user" ],
         "summary": "Create user",
@@ -177,7 +177,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/createWithArray": {
+    "/v2/api/pets/user/createWithArray": {
       "post": {
         "tags": [ "user" ],
         "summary": "Creates list of users with given input array",
@@ -199,7 +199,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/createWithList": {
+    "/v2/api/pets/user/createWithList": {
       "post": {
         "tags": [ "user" ],
         "summary": "Creates list of users with given input array",

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerPetsOnlyStore.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerPetsOnlyStore.json
@@ -11,7 +11,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
-  "basePath": "/v2",
+  "basePath": "/",
   "tags": [
     {
       "name": "store",
@@ -19,7 +19,7 @@
     }
   ],
   "paths": {
-    "/api/store/inventory": {
+    "/v2/api/store/inventory": {
       "get": {
         "tags": [ "store" ],
         "summary": "Returns pet inventories by status",
@@ -42,7 +42,7 @@
         "security": [ { "api_key": [] } ]
       }
     },
-    "/api/store/order": {
+    "/v2/api/store/order": {
       "post": {
         "tags": [ "store" ],
         "summary": "Place an order for a pet",
@@ -67,7 +67,7 @@
         }
       }
     },
-    "/api/store/order/{orderId}": {
+    "/v2/api/store/order/{orderId}": {
       "get": {
         "tags": [ "store" ],
         "summary": "Find purchase order by ID",

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerPetsTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerPetsTransformed.json
@@ -11,7 +11,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
-  "basePath": "/v2",
+  "basePath": "/",
   "tags": [
     {
       "name": "pet",
@@ -35,7 +35,7 @@
     }
   ],
   "paths": {
-    "/api/pets/pet": {
+    "/v2/api/pets/pet": {
       "post": {
         "tags": [ "pet" ],
         "summary": "Add a new pet to the store",
@@ -79,7 +79,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/pet/findByStatus": {
+    "/v2/api/pets/pet/findByStatus": {
       "get": {
         "tags": [ "pet" ],
         "summary": "Finds Pets by status",
@@ -114,7 +114,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/pet/findByTags": {
+    "/v2/api/pets/pet/findByTags": {
       "get": {
         "tags": [ "pet" ],
         "summary": "Finds Pets by tags",
@@ -146,7 +146,7 @@
         "deprecated": true
       }
     },
-    "/api/pets/pet/{petId}": {
+    "/v2/api/pets/pet/{petId}": {
       "get": {
         "tags": [ "pet" ],
         "summary": "Find pet by ID",
@@ -236,7 +236,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/pet/{petId}/uploadImage": {
+    "/v2/api/pets/pet/{petId}/uploadImage": {
       "post": {
         "tags": [ "pet" ],
         "summary": "uploads an image",
@@ -277,7 +277,7 @@
         "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
       }
     },
-    "/api/pets/store/inventory": {
+    "/v2/api/pets/store/inventory": {
       "get": {
         "tags": [ "store" ],
         "summary": "Returns pet inventories by status",
@@ -300,7 +300,7 @@
         "security": [ { "api_key": [] } ]
       }
     },
-    "/api/pets/store/order": {
+    "/v2/api/pets/store/order": {
       "post": {
         "tags": [ "store" ],
         "summary": "Place an order for a pet",
@@ -325,7 +325,7 @@
         }
       }
     },
-    "/api/pets/store/order/{orderId}": {
+    "/v2/api/pets/store/order/{orderId}": {
       "get": {
         "tags": [ "store" ],
         "summary": "Find purchase order by ID",
@@ -376,7 +376,7 @@
         }
       }
     },
-    "/api/pets/user": {
+    "/v2/api/pets/user": {
       "post": {
         "tags": [ "user" ],
         "summary": "Create user",
@@ -395,7 +395,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/createWithArray": {
+    "/v2/api/pets/user/createWithArray": {
       "post": {
         "tags": [ "user" ],
         "summary": "Creates list of users with given input array",
@@ -417,7 +417,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/createWithList": {
+    "/v2/api/pets/user/createWithList": {
       "post": {
         "tags": [ "user" ],
         "summary": "Creates list of users with given input array",
@@ -439,7 +439,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/login": {
+    "/v2/api/pets/user/login": {
       "get": {
         "tags": [ "user" ],
         "summary": "Logs user into the system",
@@ -483,7 +483,7 @@
         }
       }
     },
-    "/api/pets/user/logout": {
+    "/v2/api/pets/user/logout": {
       "get": {
         "tags": [ "user" ],
         "summary": "Logs out current logged in user session",
@@ -494,7 +494,7 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
-    "/api/pets/user/{username}": {
+    "/v2/api/pets/user/{username}": {
       "get": {
         "tags": [ "user" ],
         "summary": "Get user by user name",

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBaseTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/SwaggerWithBasePathBaseTransformed.json
@@ -4,9 +4,9 @@
     "version": "v1",
     "title": "Projects API"
   },
-  "basePath": "/api/",
+  "basePath": "/",
   "paths": {
-    "/projects/Projects": {
+    "/api/projects/Projects": {
       "get": {
         "tags": [
           "Projects"
@@ -33,7 +33,7 @@
         }
       }
     },
-    "/projects/Projects/{id}": {
+    "/api/projects/Projects/{id}": {
       "get": {
         "tags": [
           "Projects"
@@ -67,7 +67,7 @@
         }
       }
     },
-    "/projects/Projects/projectCreate": {
+    "/api/projects/Projects/projectCreate": {
       "post": {
         "tags": [
           "Projects"
@@ -100,7 +100,7 @@
         }
       }
     },
-    "/projects/Values": {
+    "/api/projects/Values": {
       "get": {
         "tags": [
           "Values"


### PR DESCRIPTION
Hello,

This change makes it so that the downstream server url does not become the upstream server url. It makes sense for the API gateway to be able to define it's own server urls. However, this ability is not implemented in PR. Currently, only 1 server is supported, therefore, there is no need to implement this right now.

Example:
If the following downstream swagger is given
```
{
  "servers": [
    {
      "url": "http://test.it/api"
    }
  ],
  "paths": {
    "/Projects": { ... }
  }
```
then the following upstream swagger is outputted.
```
{
  "servers": [
    {
      "url": ""
    }
  ],
  "paths": {
    "/api/Projects": { ... }
  }
```

Lastly, I have renamed some variables and method names. I think it's more readable. Let me know your thoughts.

Thank you.

