### PR TITLE
Add an option to reconfigure upstream swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ Direct via `http://ocelotprojecturl:port/swagger` provides documentation for dow
               };
         })
    ```
+   You can also optionally alter the upstream swagger after it has been transformed.
+   ```CSharp
+       public string AlterUpstreamSwaggerJson(HttpContext context, string swaggerJson)
+       {
+            var swagger = JObject.Parse(swaggerJson);
+            // ...
+            return swagger.ToString(Formatting.Indented);
+       }
+
+       app.UseSwaggerForOcelotUI(Configuration, opt => {
+           opts.ReConfigureUpstreamSwaggerJson = AlterUpstreamSwaggerJson;
+       })
+   ```
 6. Show your microservices interactive documentation.
    > `http://ocelotserviceurl/swagger`
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ Direct via `http://ocelotprojecturl:port/swagger` provides documentation for dow
               };
         })
    ```
-   You can also optionally alter the upstream swagger after it has been transformed.
+   After swagger for ocelot transforms the downstream swagger to the upstream swagger, you have the ability to alter the upstream swagger if you need to by setting the `ReConfigureUpstreamSwaggerJson` option or `ReConfigureUpstreamSwaggerJsonAsync` option for async methods.
    ```CSharp
        public string AlterUpstreamSwaggerJson(HttpContext context, string swaggerJson)
        {
             var swagger = JObject.Parse(swaggerJson);
-            // ...
+            // ... alter upstream json
             return swagger.ToString(Formatting.Indented);
        }
 

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -1,6 +1,7 @@
 ﻿using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace MMLib.SwaggerForOcelot.Configuration
@@ -44,5 +45,10 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// Alter swagger/openApi json after it has been transformed
         /// </summary>
         public Func<HttpContext, string, string> ReConfigureUpstreamSwaggerJson { get; set; }
+
+        /// <summary>
+        /// Alter swagger/openApi json after it has been transformed
+        /// </summary>
+        public Func<HttpContext, string, Task<string>> ReConfigureUpstreamSwaggerJsonAsync { get; set; }
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -1,6 +1,7 @@
 ﻿using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 
 namespace MMLib.SwaggerForOcelot.Configuration
 {
@@ -38,5 +39,11 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// Headers to include when requesting a downstream swagger endpoint.
         /// </summary>
         public IEnumerable<KeyValuePair<string, string>> DownstreamSwaggerHeaders { get; set; }
+
+        /// <summary>
+        /// Alter swagger/openApi json after it has been transformed
+        /// </summary>
+        public Func<HttpContext, string, string> ReConfigureUpstreamSwaggerJson { get; set; }
+
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -44,6 +44,5 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// Alter swagger/openApi json after it has been transformed
         /// </summary>
         public Func<HttpContext, string, string> ReConfigureUpstreamSwaggerJson { get; set; }
-
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -64,9 +64,30 @@ namespace MMLib.SwaggerForOcelot.Middleware
             var content = await httpClient.GetStringAsync(endPoint.Url);
             var hostName = endPoint.EndPoint.HostOverride ?? context.Request.Host.Value;
             content = _transformer.Transform(content, _reRoutes.Value.Where(p => p.SwaggerKey == endPoint.EndPoint.Key), hostName);
-            content = _options.ReConfigureUpstreamSwaggerJson?.Invoke(context, content);
+            content = await ReconfigureUpstreamSwagger(context, content);
 
             await context.Response.WriteAsync(content);
+        }
+
+        private async Task<string> ReconfigureUpstreamSwagger(HttpContext context, string swaggerJson)
+        {
+            if (_options.ReConfigureUpstreamSwaggerJson != null && _options.ReConfigureUpstreamSwaggerJsonAsync != null)
+            {
+                throw new Exception(
+                    "Both ReConfigureUpstreamSwaggerJson and ReConfigureUpstreamSwaggerJsonAsync cannot have a value. Only use one method.");
+            }
+
+            if (_options.ReConfigureUpstreamSwaggerJson != null)
+            {
+                return _options.ReConfigureUpstreamSwaggerJson(context, swaggerJson);
+            }
+
+            if (_options.ReConfigureUpstreamSwaggerJsonAsync != null)
+            {
+                return await _options.ReConfigureUpstreamSwaggerJsonAsync(context, swaggerJson);
+            }
+
+            return swaggerJson;
         }
 
         private void AddHeaders(HttpClient httpClient)

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -64,6 +64,8 @@ namespace MMLib.SwaggerForOcelot.Middleware
             var content = await httpClient.GetStringAsync(endPoint.Url);
             var hostName = endPoint.EndPoint.HostOverride ?? context.Request.Host.Value;
             content = _transformer.Transform(content, _reRoutes.Value.Where(p => p.SwaggerKey == endPoint.EndPoint.Key), hostName);
+            content = _options.ReConfigureUpstreamSwaggerJson?.Invoke(context, content);
+
 
             await context.Response.WriteAsync(content);
         }

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -66,7 +66,6 @@ namespace MMLib.SwaggerForOcelot.Middleware
             content = _transformer.Transform(content, _reRoutes.Value.Where(p => p.SwaggerKey == endPoint.EndPoint.Key), hostName);
             content = _options.ReConfigureUpstreamSwaggerJson?.Invoke(context, content);
 
-
             await context.Response.WriteAsync(content);
         }
 

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -17,6 +17,7 @@
     <None Remove="Resources\SwaggerWithInnerDefinnitionReferenceTransformed.json" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources\OpenApiBaseTransformedReconfigured.json" />
     <EmbeddedResource Include="Resources\SwaggerWithInnerDefinnitionReferenceTransformed.json">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </EmbeddedResource>
@@ -60,6 +61,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiBaseTransformedReconfigured.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiBaseTransformedReconfigured.json
@@ -1,0 +1,145 @@
+{
+  "openapi": "3.0",
+  "info": {
+    "version": "v1",
+    "title": "Projects API"
+  },
+  "paths": {
+    "/api/projects/Projects": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "Get",
+        "consumes": [],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "uniqueItems": false,
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Project"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/Projects/{id}": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "Get",
+        "consumes": [],
+        "produces": [
+          "text/plain",
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/components/schemas/Project"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/projects/Projects/projectCreate": {
+      "post": {
+        "tags": [
+          "Projects"
+        ],
+        "operationId": "CreateProject",
+        "consumes": [
+          "application/json-patch+json",
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "projectViewModel",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ProjectViewModel"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Project": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      },
+      "ProjectViewModel": {
+        "required": [
+          "name",
+          "owner"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "description": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -22,7 +22,7 @@ namespace MMLib.SwaggerForOcelot.Tests
     public class SwaggerForOcelotMiddlewareShould
     {
         [Fact]
-        public async Task UserDefinedUpstreamTransformer()
+        public async Task AllowUserDefinedUpstreamTransformer()
         {
             // Arrange
             const string version = "v1";

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -52,7 +52,6 @@ namespace MMLib.SwaggerForOcelot.Tests
                                 Name = "Test Service",
                                 Version = version,
                                 Url = $"http://test.com/{version}/{key}/swagger.json"
-                                
                             }
                         }
                     }
@@ -82,7 +81,6 @@ namespace MMLib.SwaggerForOcelot.Tests
             
             // Assert
             await AreEqual(transformedUpstreamSwagger, "OpenApiBaseTransformedReconfigured");
-
         }
 
         /// This method removes a route
@@ -121,7 +119,6 @@ namespace MMLib.SwaggerForOcelot.Tests
             context.Response.Body = new MemoryStream();
             return context;
         }
-        
 
         private HttpClient GetHttpClient(string downstreamSwagger)
         {
@@ -218,6 +215,5 @@ namespace MMLib.SwaggerForOcelot.Tests
                 return _transformedJson;
             }
         }
-
     }
 }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -1,0 +1,223 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using MMLib.SwaggerForOcelot.Configuration;
+using MMLib.SwaggerForOcelot.Middleware;
+using MMLib.SwaggerForOcelot.Transformation;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace MMLib.SwaggerForOcelot.Tests
+{
+    public class SwaggerForOcelotMiddlewareShould
+    {
+        [Fact]
+        public async Task UserDefinedUpstreamTransformer()
+        {
+            // Arrange
+            const string version = "v1";
+            const string key = "test";
+            var httpContext = GetHttpContext(requestPath: $"/{version}/{key}");
+
+            var next = new TestRequestDelegate();
+
+            // What is being tested
+            var swaggerForOcelotOptions = new SwaggerForOcelotUIOptions()
+            {
+                ReConfigureUpstreamSwaggerJson = ExampleUserDefinedUpstreamTransformer
+            };
+
+            var rerouteOptions = new TestReRouteOptions();
+
+            var swaggerEndpointOptions = new TestSwaggerEndpointOptions(
+                new List<SwaggerEndPointOptions>()
+                {
+                    new SwaggerEndPointOptions()
+                    {
+                        Key = key,
+                        Config = new List<SwaggerEndPointConfig>()
+                        {
+                            new SwaggerEndPointConfig()
+                            {
+                                Name = "Test Service",
+                                Version = version,
+                                Url = $"http://test.com/{version}/{key}/swagger.json"
+                                
+                            }
+                        }
+                    }
+                });
+
+            // downstreamSwagger is returned when client.GetStringAsync is called by the middleware.
+            var downstreamSwagger = await GetBaseOpenApi("OpenApiBase");
+            var httClientMock = GetHttpClient(downstreamSwagger);
+            var httpClientFactory = new TestHttpClientFactory(httClientMock);
+
+            // upstreamSwagger is returned after swaggerJsonTransformer transforms the downstreamSwagger
+            var upstreamSwagger = await GetBaseOpenApi("OpenApiBaseTransformed");
+            var swaggerJsonTransformer = new TestSwaggerJsonTransformer(upstreamSwagger);
+
+            var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
+                next.Invoke,
+                swaggerForOcelotOptions,
+                rerouteOptions,
+                swaggerEndpointOptions,
+                httpClientFactory,
+                swaggerJsonTransformer);
+            
+            // Act
+            await swaggerForOcelotMiddleware.Invoke(httpContext);
+            httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+            var transformedUpstreamSwagger = await new StreamReader(httpContext.Response.Body).ReadToEndAsync();
+            
+            // Assert
+            await AreEqual(transformedUpstreamSwagger, "OpenApiBaseTransformedReconfigured");
+
+        }
+
+        /// This method removes a route
+        private string ExampleUserDefinedUpstreamTransformer(HttpContext context, string openApiJson)
+        {
+            if (context.Request.Path.Value != "/v1/test")
+            {
+                return openApiJson;
+            }
+
+            const string routeToRemove = "/api/projects/Values";
+            
+            var swagger = JObject.Parse(openApiJson);
+            var paths = swagger[OpenApiProperties.Paths];
+            var pathToRemove = paths.Values<JProperty>().FirstOrDefault(c => c.Name == routeToRemove);
+            pathToRemove?.Remove();
+            return swagger.ToString(Formatting.Indented);
+        }
+
+        private static async Task AreEqual(string transformedSwagger, string expectedOpenApiFileName)
+        {
+            var transformedJson = JObject.Parse(transformedSwagger);
+            var expectedJson = JObject.Parse(await AssemblyHelper
+                .GetStringFromResourceFileAsync($"{expectedOpenApiFileName}.json"));
+
+            JObject.DeepEquals(transformedJson, expectedJson)
+                .Should()
+                .BeTrue();
+        }
+
+        private HttpContext GetHttpContext(string requestPath)
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Path = requestPath;
+            context.Request.Host = new HostString("test.com");
+            context.Response.Body = new MemoryStream();
+            return context;
+        }
+        
+
+        private HttpClient GetHttpClient(string downstreamSwagger)
+        {
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            httpMessageHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync((HttpRequestMessage request, CancellationToken token) =>
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(downstreamSwagger)
+                    };
+                    return response;
+                });
+            return new HttpClient(httpMessageHandlerMock.Object);
+        }
+
+        private async Task<string> GetBaseOpenApi(string openApiName) =>
+            await AssemblyHelper.GetStringFromResourceFileAsync($"{openApiName}.json");
+
+        private class TestRequestDelegate
+        {
+            private readonly int _statusCode;
+
+            public TestRequestDelegate(int statusCode = 200)
+            {
+                _statusCode = statusCode;
+            }
+
+            public bool Called => CalledCount > 0;
+
+            public int CalledCount { get; private set; }
+
+            public Task Invoke(HttpContext context)
+            {
+                CalledCount++;
+                return Task.CompletedTask;
+            }
+        }
+
+        private class TestHttpClientFactory : IHttpClientFactory
+        {
+            private readonly HttpClient _mockHttpClient;
+
+            public TestHttpClientFactory(HttpClient mockHttpClient)
+            {
+                _mockHttpClient = mockHttpClient;
+            }
+            public HttpClient CreateClient()
+            {
+                return _mockHttpClient;
+            }
+
+            public HttpClient CreateClient(string name)
+            {
+                return _mockHttpClient;
+            }
+        }
+        
+        private class TestReRouteOptions : IOptions<List<ReRouteOptions>>
+        {
+            public TestReRouteOptions()
+            {
+                Value = new List<ReRouteOptions>();
+            }
+            public List<ReRouteOptions> Value { get; }
+        }
+
+        private class TestSwaggerEndpointOptions : IOptions<List<SwaggerEndPointOptions>>
+        {
+            public TestSwaggerEndpointOptions(List<SwaggerEndPointOptions> options)
+            {
+                Value = options;
+            }
+            public List<SwaggerEndPointOptions> Value { get; }
+        }
+        
+        private class TestSwaggerJsonTransformer : ISwaggerJsonTransformer
+        {
+            private readonly string _transformedJson;
+
+            public TestSwaggerJsonTransformer(string transformedJson)
+            {
+                _transformedJson = transformedJson;
+            }
+            
+            public string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, string hostOverride)
+            {
+                return _transformedJson;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
I've added an option to allow for the full control of how the upstream swagger looks.
It's very useful when there are items in the downstream swagger that you don't want to appear in the upstream.