### PR TITLE
Feature/version placeholder

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
@@ -19,6 +19,11 @@ namespace MMLib.SwaggerForOcelot.Configuration
         public string Key { get; set; }
 
         /// <summary>
+        /// Swagger version placeholder..
+        /// </summary>
+        public string VersionPlaceholder { get; set; } = "{version}";
+
+        /// <summary>
         /// Gets the path from key.
         /// </summary>
         public string KeyToPath => WebUtility.UrlEncode(Key);

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -33,6 +33,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
         /// <param name="reRoutes">The Ocelot ReRoutes configuration.</param>
         /// <param name="swaggerEndPoints">The swagger end points.</param>
         /// <param name="httpClientFactory">The HTTP client factory.</param>
+        /// <param name="transformer">The SwaggerJsonTransformer</param>
         public SwaggerForOcelotMiddleware(
             RequestDelegate next,
             SwaggerForOcelotUIOptions options,
@@ -63,10 +64,42 @@ namespace MMLib.SwaggerForOcelot.Middleware
             AddHeaders(httpClient);
             var content = await httpClient.GetStringAsync(endPoint.Url);
             var hostName = endPoint.EndPoint.HostOverride ?? context.Request.Host.Value;
-            content = _transformer.Transform(content, _reRoutes.Value.Where(p => p.SwaggerKey == endPoint.EndPoint.Key), hostName);
+            var reRouteOptions = ExpandReRouteOptions(endPoint.EndPoint);
+
+            content = _transformer.Transform(content, reRouteOptions, hostName);
             content = await ReconfigureUpstreamSwagger(context, content);
 
             await context.Response.WriteAsync(content);
+        }
+
+        private IEnumerable<ReRouteOptions> ExpandReRouteOptions(SwaggerEndPointOptions endPoint)
+        {
+            var reRouteOptions = _reRoutes.Value.Where(p => p.SwaggerKey == endPoint.Key).ToList();
+
+            if (string.IsNullOrWhiteSpace(endPoint.VersionPlaceholder)) 
+                return reRouteOptions;
+
+            var versionReRouteOptions = reRouteOptions.Where(x =>
+                x.DownstreamPathTemplate.Contains(endPoint.VersionPlaceholder)
+                || x.UpstreamPathTemplate.Contains(endPoint.VersionPlaceholder)).ToList();
+            versionReRouteOptions.ForEach(o => reRouteOptions.Remove(o));
+            foreach(var reRouteOption in versionReRouteOptions) {
+                var versionMappedReRouteOptions = endPoint.Config.Select(c => new ReRouteOptions()
+                {
+                    SwaggerKey = reRouteOption.SwaggerKey,
+                    DownstreamPathTemplate =
+                        reRouteOption.DownstreamPathTemplate.Replace(endPoint.VersionPlaceholder,
+                            c.Version),
+                    UpstreamHttpMethod = reRouteOption.UpstreamHttpMethod,
+                    UpstreamPathTemplate =
+                        reRouteOption.UpstreamPathTemplate.Replace(endPoint.VersionPlaceholder,
+                            c.Version),
+                    VirtualDirectory = reRouteOption.VirtualDirectory
+                });
+                reRouteOptions.AddRange(versionMappedReRouteOptions);
+            }
+
+            return reRouteOptions;
         }
 
         private async Task<string> ReconfigureUpstreamSwagger(HttpContext context, string swaggerJson)

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -4,6 +4,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Resources\OpenApiWithVersionPlaceholderBase.json" />
+    <None Remove="Resources\OpenApiWithVersionPlaceholderBaseTransformed.json" />
     <None Remove="Resources\SwaggerBase.json" />
     <None Remove="Resources\SwaggerBaseTransformed.json" />
     <None Remove="Resources\SwaggerNestedClass.json" />
@@ -18,6 +20,8 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\OpenApiBaseTransformedReconfigured.json" />
+    <EmbeddedResource Include="Resources\OpenApiWithVersionPlaceholderBase.json" />
+    <EmbeddedResource Include="Resources\OpenApiWithVersionPlaceholderBaseTransformed.json" />
     <EmbeddedResource Include="Resources\SwaggerWithInnerDefinnitionReferenceTransformed.json">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </EmbeddedResource>

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithVersionPlaceholderBase.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithVersionPlaceholderBase.json
@@ -1,0 +1,172 @@
+{
+    "openapi": "3.0",
+    "info": {
+        "version": "v1",
+        "title": "Projects API"
+    },
+    "paths": {
+        "/api/Projects": {
+            "get": {
+                "tags": [
+                    "Projects"
+                ],
+                "operationId": "Get",
+                "consumes": [],
+                "produces": [
+                    "text/plain",
+                    "application/json",
+                    "text/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "uniqueItems": false,
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/Project"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/Projects/{id}": {
+            "get": {
+                "tags": [
+                    "Projects"
+                ],
+                "operationId": "Get",
+                "consumes": [],
+                "produces": [
+                    "text/plain",
+                    "application/json",
+                    "text/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/components/schemas/Project"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    }
+                }
+            }
+        },
+        "/api/Projects/projectCreate": {
+            "post": {
+                "tags": [
+                    "Projects"
+                ],
+                "operationId": "CreateProject",
+                "consumes": [
+                    "application/json-patch+json",
+                    "application/json",
+                    "text/json",
+                    "application/*+json"
+                ],
+                "produces": [],
+                "parameters": [
+                    {
+                        "name": "projectViewModel",
+                        "in": "body",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/ProjectViewModel"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    }
+                }
+            }
+        },
+        "/api/v1/Values": {
+            "get": {
+                "tags": [
+                    "Values"
+                ],
+                "operationId": "Get",
+                "consumes": [],
+                "produces": [
+                    "text/plain",
+                    "application/json",
+                    "text/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "uniqueItems": false,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Project": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "owner": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ProjectViewModel": {
+                "required": [
+                    "name",
+                    "owner"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 50,
+                        "type": "string"
+                    },
+                    "description": {
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "owner": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithVersionPlaceholderBaseTransformed.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/OpenApiWithVersionPlaceholderBaseTransformed.json
@@ -1,0 +1,172 @@
+{
+    "openapi": "3.0",
+    "info": {
+        "version": "v1",
+        "title": "Projects API"
+    },
+    "paths": {
+        "/api/projects/Projects": {
+            "get": {
+                "tags": [
+                    "Projects"
+                ],
+                "operationId": "Get",
+                "consumes": [],
+                "produces": [
+                    "text/plain",
+                    "application/json",
+                    "text/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "uniqueItems": false,
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/Project"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/projects/Projects/{id}": {
+            "get": {
+                "tags": [
+                    "Projects"
+                ],
+                "operationId": "Get",
+                "consumes": [],
+                "produces": [
+                    "text/plain",
+                    "application/json",
+                    "text/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/components/schemas/Project"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    }
+                }
+            }
+        },
+        "/api/projects/Projects/projectCreate": {
+            "post": {
+                "tags": [
+                    "Projects"
+                ],
+                "operationId": "CreateProject",
+                "consumes": [
+                    "application/json-patch+json",
+                    "application/json",
+                    "text/json",
+                    "application/*+json"
+                ],
+                "produces": [],
+                "parameters": [
+                    {
+                        "name": "projectViewModel",
+                        "in": "body",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/ProjectViewModel"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/Values": {
+            "get": {
+                "tags": [
+                    "Values"
+                ],
+                "operationId": "Get",
+                "consumes": [],
+                "produces": [
+                    "text/plain",
+                    "application/json",
+                    "text/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "uniqueItems": false,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Project": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "owner": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ProjectViewModel": {
+                "required": [
+                    "name",
+                    "owner"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 50,
+                        "type": "string"
+                    },
+                    "description": {
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "owner": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
As suggested in #19 I implemented a function that translates all paths within the reroute options with all configured swagger endpoint versions using the defined version placeholder. Also included unit test.
My first idea was to make a more generic parameter translator as suggested in the isue, but later decided that this version placeholder was easier to build and more specific in terms of functionality. Thank you for the great library. I specially like the way you setup the unit tests.