### PR TITLE
.NET Core 3 support/Swagger 5 rc-4/Ocelot 13.9 alpha 

### DIFF
--- a/demo/ApiGateway/ApiGateway.csproj
+++ b/demo/ApiGateway/ApiGateway.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Ocelot" Version="12.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Ocelot" Version="13.9.0-alpha0115" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/ApiGateway/Program.cs
+++ b/demo/ApiGateway/Program.cs
@@ -24,7 +24,6 @@ namespace ApiGateway
                         .AddJsonFile("ocelot.json")
                         .AddEnvironmentVariables();
                 })
-
                 .UseStartup<Startup>();
     }
 }

--- a/demo/ApiGateway/Program.cs
+++ b/demo/ApiGateway/Program.cs
@@ -24,6 +24,7 @@ namespace ApiGateway
                         .AddJsonFile("ocelot.json")
                         .AddEnvironmentVariables();
                 })
+
                 .UseStartup<Startup>();
     }
 }

--- a/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
+++ b/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Ocelot" Version="12.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Ocelot" Version="13.9.0-alpha0115" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/ContactService/ContactService.csproj
+++ b/demo/ContactService/ContactService.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
   </ItemGroup>
 
 </Project>

--- a/demo/ContactService/Program.cs
+++ b/demo/ContactService/Program.cs
@@ -19,6 +19,7 @@ namespace ContactService
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .UseUrls("http://0.0.0.0:5100");
     }
 }

--- a/demo/ContactService/Startup.cs
+++ b/demo/ContactService/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 
 namespace ContactService
@@ -22,7 +23,7 @@ namespace ContactService
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info { Title = "Contacts API", Version = "v1" });
+                c.SwaggerDoc("v1", new OpenApiInfo() { Title = "Contacts API", Version = "v1" });
             });
         }
 
@@ -38,7 +39,7 @@ namespace ContactService
                 app.UseHsts();
             }
 
-            app.UseMvc();
+            app.UseRouting();
             app.UseSwagger()
                 .UseSwaggerUI(c =>
                 {

--- a/demo/OrderService/ConfigureSwaggerOptions.cs
+++ b/demo/OrderService/ConfigureSwaggerOptions.cs
@@ -1,6 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
+﻿using System;
+using System.ComponentModel;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -19,32 +22,32 @@ namespace OrderService
         /// Initializes a new instance of the <see cref="ConfigureSwaggerOptions"/> class.
         /// </summary>
         /// <param name="provider">The <see cref="IApiVersionDescriptionProvider">provider</see> used to generate Swagger documents.</param>
-        public ConfigureSwaggerOptions( IApiVersionDescriptionProvider provider ) => this.provider = provider;
+        public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider) => this.provider = provider;
 
         /// <inheritdoc />
-        public void Configure( SwaggerGenOptions options )
+        public void Configure(SwaggerGenOptions options)
         {
             // add a swagger document for each discovered API version
             // note: you might choose to skip or document deprecated API versions differently
-            foreach ( var description in provider.ApiVersionDescriptions )
+            foreach (var description in provider.ApiVersionDescriptions)
             {
-                options.SwaggerDoc( description.GroupName, CreateInfoForApiVersion( description ) );
+                options.SwaggerDoc(description.GroupName, CreateInfoForApiVersion(description));
             }
         }
 
-        static Info CreateInfoForApiVersion( ApiVersionDescription description )
+        static OpenApiInfo CreateInfoForApiVersion(ApiVersionDescription description)
         {
-            var info = new Info()
+            var info = new OpenApiInfo()
             {
                 Title = "Sample API",
                 Version = description.ApiVersion.ToString(),
                 Description = "A sample application with Swagger, Swashbuckle, and API versioning.",
-                Contact = new Contact() { Name = "Bill Mei", Email = "bill.mei@somewhere.com" },
-                TermsOfService = "Shareware",
-                License = new License() { Name = "MIT", Url = "https://opensource.org/licenses/MIT" }
+                Contact = new OpenApiContact() { Name = "Bill Mei", Email = "bill.mei@somewhere.com" },
+                TermsOfService = new Uri("https://your-terms-of-service.com/tos"),
+                License = new OpenApiLicense() { Name = "MIT", Url = new Uri("https://opensource.org/licenses/MIT") }
             };
 
-            if ( description.IsDeprecated )
+            if (description.IsDeprecated)
             {
                 info.Description += " This API version has been deprecated.";
             }

--- a/demo/OrderService/NonBodyParameter.cs
+++ b/demo/OrderService/NonBodyParameter.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.OpenApi.Models;
+
+namespace OrderService
+{
+    public class NonBodyParameter : OpenApiParameter
+    {
+        public object Default { get; set; }
+    }
+}

--- a/demo/OrderService/OrderService.csproj
+++ b/demo/OrderService/OrderService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
  <PropertyGroup>
-  <TargetFramework>netcoreapp2.2</TargetFramework>
+  <TargetFramework>netcoreapp3.0</TargetFramework>
   <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   <RootNamespace>OrderService</RootNamespace>
   <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildThisFileName).xml</DocumentationFile>
@@ -9,10 +9,10 @@
 
  <ItemGroup>
   <PackageReference Include="Microsoft.AspNetCore.App" />
-  <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="3.2.0" />
+  <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.0.0" />
   <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-  <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+  <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
  </ItemGroup>
 
 

--- a/demo/OrderService/Program.cs
+++ b/demo/OrderService/Program.cs
@@ -12,16 +12,17 @@ namespace OrderService
         /// The main entry point to the application.
         /// </summary>
         /// <param name="args">The arguments provided at start-up, if any.</param>
-        public static void Main( string[] args ) =>
-            CreateWebHostBuilder( args ).Build().Run();
+        public static void Main(string[] args) =>
+            CreateWebHostBuilder(args).Build().Run();
 
         /// <summary>
         /// Builds a new web host for the application.
         /// </summary>
         /// <param name="args">The command-line arguments, if any.</param>
         /// <returns>A new <see cref="IWebHostBuilder">web host builder</see>.</returns>
-        public static IWebHostBuilder CreateWebHostBuilder( string[] args ) =>
-            WebHost.CreateDefaultBuilder( args )
-                   .UseStartup<Startup>();
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                   .UseStartup<Startup>()
+                   .UseUrls("http://0.0.0.0:5400");
     }
 }

--- a/demo/OrderService/Startup.cs
+++ b/demo/OrderService/Startup.cs
@@ -21,7 +21,7 @@ namespace OrderService
         /// Initializes a new instance of the <see cref="Startup"/> class.
         /// </summary>
         /// <param name="configuration">The current configuration.</param>
-        public Startup( IConfiguration configuration )
+        public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
         }
@@ -36,17 +36,17 @@ namespace OrderService
         /// Configures services for the application.
         /// </summary>
         /// <param name="services">The collection of services to configure the application with.</param>
-        public void ConfigureServices( IServiceCollection services )
+        public void ConfigureServices(IServiceCollection services)
         {
             // the sample application always uses the latest version, but you may want an explicit version such as Version_2_2
             // note: Endpoint Routing is enabled by default; however, if you need legacy style routing via IRouter, change it to false
-            services.AddMvc( options => options.EnableEndpointRouting = true ).SetCompatibilityVersion( Latest );
+            services.AddMvc(options => options.EnableEndpointRouting = true).SetCompatibilityVersion(Latest);
             services.AddApiVersioning(
                 options =>
                 {
                     // reporting api versions will return the headers "api-supported-versions" and "api-deprecated-versions"
                     options.ReportApiVersions = true;
-                } );
+                });
             services.AddVersionedApiExplorer(
                 options =>
                 {
@@ -57,7 +57,7 @@ namespace OrderService
                     // note: this option is only necessary when versioning by url segment. the SubstitutionFormat
                     // can also be used to control the format of the API version in route templates
                     options.SubstituteApiVersionInUrl = true;
-                } );
+                });
             services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();
             services.AddSwaggerGen(
                 options =>
@@ -66,8 +66,8 @@ namespace OrderService
                     options.OperationFilter<SwaggerDefaultValues>();
 
                     // integrate xml comments
-                    options.IncludeXmlComments( XmlCommentsFilePath );
-                } );
+                    options.IncludeXmlComments(XmlCommentsFilePath);
+                });
         }
 
         /// <summary>
@@ -76,19 +76,19 @@ namespace OrderService
         /// <param name="app">The current application builder.</param>
         /// <param name="env">The current hosting environment.</param>
         /// <param name="provider">The API version descriptor provider used to enumerate defined API versions.</param>
-        public void Configure( IApplicationBuilder app, IHostingEnvironment env, IApiVersionDescriptionProvider provider )
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApiVersionDescriptionProvider provider)
         {
-            app.UseMvc();
+            app.UseRouting();
             app.UseSwagger();
             app.UseSwaggerUI(
                 options =>
                 {
                     // build a swagger endpoint for each discovered API version
-                    foreach ( var description in provider.ApiVersionDescriptions )
+                    foreach (var description in provider.ApiVersionDescriptions)
                     {
-                        options.SwaggerEndpoint( $"/swagger/{description.GroupName}/swagger.json", description.GroupName.ToUpperInvariant() );
+                        options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", description.GroupName.ToUpperInvariant());
                     }
-                } );
+                });
         }
 
         static string XmlCommentsFilePath
@@ -96,8 +96,8 @@ namespace OrderService
             get
             {
                 var basePath = PlatformServices.Default.Application.ApplicationBasePath;
-                var fileName = typeof( Startup ).GetTypeInfo().Assembly.GetName().Name + ".xml";
-                return Path.Combine( basePath, fileName );
+                var fileName = typeof(Startup).GetTypeInfo().Assembly.GetName().Name + ".xml";
+                return Path.Combine(basePath, fileName);
             }
         }
     }

--- a/demo/OrderService/SwaggerDefaultValues.cs
+++ b/demo/OrderService/SwaggerDefaultValues.cs
@@ -49,9 +49,4 @@ namespace OrderService
             }
         }
     }
-
-    public class NonBodyParameter : OpenApiParameter
-    {
-        public object Default { get; set; }
-    }
 }

--- a/demo/OrderService/SwaggerDefaultValues.cs
+++ b/demo/OrderService/SwaggerDefaultValues.cs
@@ -2,6 +2,7 @@
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Linq;
+using Microsoft.OpenApi.Models;
 
 namespace OrderService
 {
@@ -17,29 +18,29 @@ namespace OrderService
         /// </summary>
         /// <param name="operation">The operation to apply the filter to.</param>
         /// <param name="context">The current operation filter context.</param>
-        public void Apply( Operation operation, OperationFilterContext context )
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
             var apiDescription = context.ApiDescription;
 
             operation.Deprecated = apiDescription.IsDeprecated();
 
-            if ( operation.Parameters == null )
+            if (operation.Parameters == null)
             {
                 return;
             }
 
             // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/412
             // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/413
-            foreach ( var parameter in operation.Parameters.OfType<NonBodyParameter>() )
+            foreach (var parameter in operation.Parameters.OfType<NonBodyParameter>())
             {
-                var description = apiDescription.ParameterDescriptions.First( p => p.Name == parameter.Name );
+                var description = apiDescription.ParameterDescriptions.First(p => p.Name == parameter.Name);
 
-                if ( parameter.Description == null )
+                if (parameter.Description == null)
                 {
                     parameter.Description = description.ModelMetadata?.Description;
                 }
 
-                if ( parameter.Default == null )
+                if (parameter.Default == null)
                 {
                     parameter.Default = description.DefaultValue;
                 }
@@ -47,5 +48,10 @@ namespace OrderService
                 parameter.Required |= description.IsRequired;
             }
         }
+    }
+
+    public class NonBodyParameter : OpenApiParameter
+    {
+        public object Default { get; set; }
     }
 }

--- a/demo/OrderService/web.config
+++ b/demo/OrderService/web.config
@@ -10,6 +10,7 @@
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" hostingModel="InProcess">
       <environmentVariables>
         <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+        <environmentVariable name="COMPLUS_ForceENC" value="1" />
       </environmentVariables>
     </aspNetCore>
   </system.webServer>

--- a/demo/PetstoreService/PetstoreService.csproj
+++ b/demo/PetstoreService/PetstoreService.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/demo/PetstoreService/Program.cs
+++ b/demo/PetstoreService/Program.cs
@@ -19,6 +19,7 @@ namespace PetstoreService
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .UseUrls("http://0.0.0.0:5300");
     }
 }

--- a/demo/ProjectService/Program.cs
+++ b/demo/ProjectService/Program.cs
@@ -19,6 +19,7 @@ namespace ProjectService
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .UseUrls("http://0.0.0.0:5200");
     }
 }

--- a/demo/ProjectService/ProjectService.csproj
+++ b/demo/ProjectService/ProjectService.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="MMLib.RapidPrototyping" Version="1.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
   </ItemGroup>
 
 </Project>

--- a/demo/ProjectService/Startup.cs
+++ b/demo/ProjectService/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 
 namespace ProjectService
@@ -22,7 +23,8 @@ namespace ProjectService
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info { Title = "Projects API", Version = "v1" });
+                c.SwaggerDoc("v1", new OpenApiInfo()
+                { Title = "Projects API", Version = "v1" });
             });
         }
 
@@ -37,8 +39,9 @@ namespace ProjectService
             {
                 app.UseHsts();
             }
-            app.UseStaticFiles();
-            app.UseMvc();
+
+            app.UseRouting();
+
             app.UseSwagger()
                 .UseSwaggerUI(c =>
                 {

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -24,8 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Kros.Utils" Version="1.10.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0-preview3.19553.2" />
-    <PackageReference Include="Ocelot" Version="13.9.0-alpha0115" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.1" />
+    <PackageReference Include="Ocelot" Version="13.8.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.0.0-rc4" />
   </ItemGroup>
 

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3</TargetFramework>
     <Version>1.9.0</Version>
     <Authors>Milan Martiniak</Authors>
     <Company>MMLib</Company>
@@ -23,10 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kros.Utils" Version="1.8.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
-    <PackageReference Include="Ocelot" Version="12.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="4.0.1" />
+    <PackageReference Include="Kros.Utils" Version="1.10.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0-preview3.19553.2" />
+    <PackageReference Include="Ocelot" Version="13.9.0-alpha0115" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.0.0-rc4" />
   </ItemGroup>
 
 </Project>

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -85,17 +85,19 @@ namespace MMLib.SwaggerForOcelot.Transformation
                     (downstreamUrl.IsAbsoluteUri ? downstreamUrl.AbsolutePath : downstreamUrl.OriginalString)
                     .RemoveSlashFromEnd();
             }
-            
+
             var paths = openApi[OpenApiProperties.Paths];
             if (paths != null)
             {
                 RenameAndRemovePaths(reRoutes, paths, downstreamBasePath);
 
-                RemoveItems<JProperty>(
-                    openApi[OpenApiProperties.Components][OpenApiProperties.Schemas],
-                    paths,
-                    i => $"$..[?(@*.$ref == '#/{OpenApiProperties.Components}/{OpenApiProperties.Schemas}/{i.Name}')]",
-                    i => $"$..[?(@*.*.items.$ref == '#/{OpenApiProperties.Components}/{OpenApiProperties.Schemas}/{i.Name}')]");
+                var schemaToken = openApi[OpenApiProperties.Components][OpenApiProperties.Schemas];
+                if (schemaToken != null)
+                    RemoveItems<JProperty>(schemaToken,
+                        paths,
+                        i => $"$..[?(@*.$ref == '#/{OpenApiProperties.Components}/{OpenApiProperties.Schemas}/{i.Name}')]",
+                        i => $"$..[?(@*.*.items.$ref == '#/{OpenApiProperties.Components}/{OpenApiProperties.Schemas}/{i.Name}')]");
+
                 if (openApi["tags"] != null)
                 {
                     RemoveItems<JObject>(
@@ -244,7 +246,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
             var newProperty = new JProperty(newName, property.Value);
             property.Replace(newProperty);
         }
-        
+
         private static void TransformServerPaths(JObject openApi, string hostOverride)
         {
             if (!openApi.ContainsKey(OpenApiProperties.Servers)) return;

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -93,10 +93,12 @@ namespace MMLib.SwaggerForOcelot.Transformation
 
                 var schemaToken = openApi[OpenApiProperties.Components][OpenApiProperties.Schemas];
                 if (schemaToken != null)
+                {
                     RemoveItems<JProperty>(schemaToken,
                         paths,
                         i => $"$..[?(@*.$ref == '#/{OpenApiProperties.Components}/{OpenApiProperties.Schemas}/{i.Name}')]",
                         i => $"$..[?(@*.*.items.$ref == '#/{OpenApiProperties.Components}/{OpenApiProperties.Schemas}/{i.Name}')]");
+                }
 
                 if (openApi["tags"] != null)
                 {

--- a/tests/MMLib.SwaggerForOcelot.Tests/BuilderExtensionsShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/BuilderExtensionsShould.cs
@@ -1,11 +1,11 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MMLib.SwaggerForOcelot.Configuration;
 using System;
 using System.IO;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace MMLib.SwaggerForOcelot.Tests
@@ -17,7 +17,7 @@ namespace MMLib.SwaggerForOcelot.Tests
 
         [Fact]
         public void ThrowWhenSwaggerEndPointsSectionIsEmpty()
-            => TestWithInvalidConfiguration($"{{{SwaggerEndPointOptions.ConfigurationSectionName}:[]}}");
+            => TestWithInvalidConfiguration($"{{\"{SwaggerEndPointOptions.ConfigurationSectionName}\":[]}}");
 
         private void TestWithInvalidConfiguration(string jsonConfiguration)
         {

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20191115-01" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -63,10 +63,10 @@
     <EmbeddedResource Include="Resources\SwaggerBaseTransformed.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.5.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20191115-01" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
I've added support to .net core 3, technically .NET Standard is no longer supported by Ocelot from version 13.8 so i was forced to use .NET Core 3 and change the project target.
Only one unit test failed which i fixed by fixing the JSON appsettings sample.
I changed UseMvc to UseRouting
Fixed the services ports 5100,5200,5300,5400 to be referenced by the gateway
Finally, one case failed (contact API), it seems that getting the schema under the component object of the contact API returns null token which was given to **RemoveItems** function in **SwaggerJsonTransformer.cs**  i fixed it by performing a null check.

