### PR TITLE
Performance issues. Long checking if reference exist

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Configuration/ReRouteOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/ReRouteOptions.cs
@@ -133,7 +133,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// Converts to string.
         /// </summary>
         /// <returns>
-        /// A <see cref="System.String" /> that represents this instance.
+        /// A <see cref="string" /> that represents this instance.
         /// </returns>
         public override string ToString()
             => $"{UpstreamPathTemplate} => {DownstreamPathTemplate} | ({UpstreamPath} => {DownstreamPath})";

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -210,7 +210,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                 JToken patch = jdp.Diff(transformedJson, expectedJson);
 
                 throw new XunitException(
-                    $"Transformed upstream swagger is not equal to expected. {Environment.NewLine} Diff: {patch.ToString()}");
+                    $"Transformed upstream swagger is not equal to expected. {Environment.NewLine} Diff: {patch}");
             }
         }
 

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
@@ -37,7 +37,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                 JToken patch = jdp.Diff(actual, expected);
 
                 throw new XunitException(
-                    $"Transformed upstream swagger is not equal to expected. {Environment.NewLine} Diff: {patch.ToString()}");
+                    $"Transformed upstream swagger is not equal to expected. {Environment.NewLine} Diff: {patch}");
             }
         }
     }


### PR DESCRIPTION
As hotfix I try run check as paraller. In test swagger it reduce time of 40%.

Now, I don't know how get rid of the jpath.