### PR TITLE
Fixed service discovery schema when kubernetes is used

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core if needed
-      uses: actions/setup-dotnet@v1.2.0
+      uses: actions/setup-dotnet@v1.4.0
       with:
         dotnet-version: 3.1.100
     - name: Build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core if needed
-      uses: actions/setup-dotnet@v0.0.0
+      uses: actions/setup-dotnet@v1.2.0
       with:
         dotnet-version: 3.1.100
     - name: Build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core if needed
-      uses: actions/setup-dotnet@v1.2.0
+      uses: actions/setup-dotnet@v0.0.0
       with:
         dotnet-version: 3.1.100
     - name: Build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,7 +61,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/demo/ApiGateway/bin/Debug/netcoreapp3.0/ApiGateway.dll",
+            "program": "${workspaceFolder}/demo/ApiGateway/bin/Debug/netcoreapp3.1/ApiGateway.dll",
             "args": [],
             "cwd": "${workspaceFolder}/demo/ApiGateway",
             "stopAtEntry": false,            

--- a/src/MMLib.SwaggerForOcelot/Configuration/ReRouteOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/ReRouteOptions.cs
@@ -1,7 +1,7 @@
-﻿using Kros.Extensions;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Kros.Extensions;
 
 namespace MMLib.SwaggerForOcelot.Configuration
 {
@@ -21,10 +21,9 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// </summary>
         public ReRouteOptions()
         {
-            _httpMethods = new Lazy<HashSet<string>>(()
-                => new HashSet<string>(
-                    UpstreamHttpMethod?.Count() > 0 ? UpstreamHttpMethod : _defaultMethodsTypes,
-                    StringComparer.OrdinalIgnoreCase));
+            _httpMethods = new Lazy<HashSet<string>>(() => new HashSet<string>(
+                UpstreamHttpMethod?.Count() > 0 ? UpstreamHttpMethod : _defaultMethodsTypes,
+                StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -40,8 +39,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
             string upstreamPathTemplate,
             string downstreamPathTemplate,
             string virtualDirectory,
-            IEnumerable<string> upstreamMethods)
-            : this()
+            IEnumerable<string> upstreamMethods) : this()
         {
             SwaggerKey = swaggerKey;
             UpstreamPathTemplate = upstreamPathTemplate;
@@ -77,6 +75,11 @@ namespace MMLib.SwaggerForOcelot.Configuration
         public string UpstreamPathTemplate { get; set; }
 
         /// <summary>
+        /// Downstream scheme.
+        /// </summary>
+        public string DownstreamScheme { get; set; }
+
+        /// <summary>
         /// Gets or sets the upstream HTTP method.
         /// </summary>
         public IEnumerable<string> UpstreamHttpMethod { get; set; }
@@ -88,8 +91,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// <returns>
         ///   <c>true</c> if [contains HTTP method] [the specified method type]; otherwise, <c>false</c>.
         /// </returns>
-        internal bool ContainsHttpMethod(string methodType)
-            => _httpMethods.Value.Contains(methodType);
+        internal bool ContainsHttpMethod(string methodType) => _httpMethods.Value.Contains(methodType);
 
         /// <summary>
         /// Gets or sets the virtual directory, where is host service.
@@ -145,7 +147,6 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// <returns>
         /// A <see cref="string" /> that represents this instance.
         /// </returns>
-        public override string ToString()
-            => $"{UpstreamPathTemplate} => {DownstreamPathTemplate} | ({UpstreamPath} => {DownstreamPath})";
+        public override string ToString() => $"{UpstreamPathTemplate} => {DownstreamPathTemplate} | ({UpstreamPath} => {DownstreamPath})";
     }
 }

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -14,7 +14,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>@MMLib</Copyright>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
@@ -1,4 +1,4 @@
-﻿using Kros.Extensions;
+using Kros.Extensions;
 using Microsoft.Extensions.Options;
 using MMLib.SwaggerForOcelot.Configuration;
 using Ocelot.Configuration.Builder;
@@ -69,11 +69,20 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
                 throw new InvalidOperationException(GetErrorMessage(endPoint));
             }
 
-            var builder = new UriBuilder(service.Scheme, service.DownstreamHost, service.DownstreamPort);
+            var builder = new UriBuilder(GetScheme(service), service.DownstreamHost, service.DownstreamPort);
             builder.Path = endPoint.Service.Path;
 
             return builder.Uri;
         }
+
+        private string GetScheme(ServiceHostAndPort service) =>
+          !service.Scheme.IsNullOrEmpty() 
+          ? service.Scheme
+          : service.DownstreamPort switch {
+              443 => Uri.UriSchemeHttps,
+              80  => Uri.UriSchemeHttp,
+              _   => string.Empty,
+          };
 
         private static string GetErrorMessage(SwaggerEndPointConfig endPoint)
             => $"Service with swagger documentation '{endPoint.Service.Name}' cann't be discovered";

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Kros.Extensions;
 using Microsoft.Extensions.Options;
 using MMLib.SwaggerForOcelot.Configuration;
@@ -6,9 +9,6 @@ using Ocelot.Configuration.Creator;
 using Ocelot.Configuration.File;
 using Ocelot.ServiceDiscovery;
 using Ocelot.Values;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace MMLib.SwaggerForOcelot.ServiceDiscovery
 {
@@ -75,16 +75,19 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
             return builder.Uri;
         }
 
-        private string GetScheme(ServiceHostAndPort service, ReRouteOptions reRoute) =>
-          reRoute.DownstreamScheme ?? service.Scheme
-          ??
-          service.DownstreamPort switch {
-              443 => Uri.UriSchemeHttps,
-              80  => Uri.UriSchemeHttp,
-              _   => string.Empty,
-          };
+        private string GetScheme(ServiceHostAndPort service, ReRouteOptions reRoute) 
+            => !reRoute.DownstreamScheme.IsNullOrEmpty()
+            ? reRoute.DownstreamScheme
+            : !service.Scheme.IsNullOrEmpty()
+            ? service.Scheme
+            : service.DownstreamPort
+        switch
+        {
+            443 => Uri.UriSchemeHttps,
+            80 => Uri.UriSchemeHttp,
+            _ => string.Empty,
+        };
 
-        private static string GetErrorMessage(SwaggerEndPointConfig endPoint)
-            => $"Service with swagger documentation '{endPoint.Service.Name}' cann't be discovered";
+        private static string GetErrorMessage(SwaggerEndPointConfig endPoint) => $"Service with swagger documentation '{endPoint.Service.Name}' cann't be discovered";
     }
 }

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
@@ -69,16 +69,16 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
                 throw new InvalidOperationException(GetErrorMessage(endPoint));
             }
 
-            var builder = new UriBuilder(GetScheme(service), service.DownstreamHost, service.DownstreamPort);
+            var builder = new UriBuilder(GetScheme(service, reRoute), service.DownstreamHost, service.DownstreamPort);
             builder.Path = endPoint.Service.Path;
 
             return builder.Uri;
         }
 
-        private string GetScheme(ServiceHostAndPort service) =>
-          !service.Scheme.IsNullOrEmpty() 
-          ? service.Scheme
-          : service.DownstreamPort switch {
+        private string GetScheme(ServiceHostAndPort service, ReRouteOptions reRoute) =>
+          reRoute.DownstreamScheme ?? service.Scheme
+          ??
+          service.DownstreamPort switch {
               443 => Uri.UriSchemeHttps,
               80  => Uri.UriSchemeHttp,
               _   => string.Empty,


### PR DESCRIPTION
Fixed #76 

Incorrect schema was given when Kubernetes service discovery provider is used.

Scheme is discovered as followed:

1. ReRoute `DownstreamScheme` is used if is not `NullOrEmpty`
2. Scheme from `IServiceDiscoveryProvider` is used if is not `NullOrEmpty`
3. Otherwise is scheme detected by port: `443 => HTTPS` and `80 => HTTP`

Thanks to @Adamantinu