### PR TITLE
Adding AddOcelotWithSwaggerSupport

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerFileConfiguration.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerFileConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using Ocelot.Configuration.File;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MMLib.SwaggerForOcelot.Configuration
+{
+    public class SwaggerFileConfiguration
+    {
+        public List<SwaggerFileReRoute> ReRoutes { get; set; } = new List<SwaggerFileReRoute>();
+
+        public List<FileDynamicReRoute> DynamicReRoutes { get; set; } = new List<FileDynamicReRoute>();
+
+        // Seperate field for aggregates because this let's you re-use ReRoutes in multiple Aggregates
+        public List<FileAggregateReRoute> Aggregates { get; set; } = new List<FileAggregateReRoute>();
+
+        public FileGlobalConfiguration GlobalConfiguration { get; set; } = new FileGlobalConfiguration();
+
+        public List<SwaggerEndPointOptions> SwaggerEndPoints { get; set; } = new List<SwaggerEndPointOptions>();
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerFileReRoute.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerFileReRoute.cs
@@ -1,0 +1,12 @@
+﻿using Ocelot.Configuration.File;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MMLib.SwaggerForOcelot.Configuration
+{
+    public class SwaggerFileReRoute : FileReRoute
+    {
+        public string SwaggerKey { get; set; }
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using MMLib.SwaggerForOcelot.Configuration;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace MMLib.SwaggerForOcelot.DependencyInjection
+{
+    public static class ConfigurationBuilderExtensions
+    {
+        public static IConfigurationBuilder AddOcelotWithSwaggerSupport(this IConfigurationBuilder builder, string folder, IWebHostEnvironment env)
+        {
+            string primaryConfigFile = "ocelot.json";
+
+            string globalConfigFile = "ocelot.global.json";
+
+            string SwaggerEndPointsConfigFile = "ocelot.SwaggerEndPoints.json";
+
+            string subConfigPattern = @"^ocelot\.(.*?)\.json$";
+
+            string excludeConfigName = env?.EnvironmentName != null ? $"ocelot.{env.EnvironmentName}.json" : string.Empty;
+
+            var reg = new Regex(subConfigPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            var files = new DirectoryInfo(folder)
+                .EnumerateFiles()
+                .Where(fi => reg.IsMatch(fi.Name) && (fi.Name != excludeConfigName))
+                .ToList();
+
+            var fileConfiguration = new SwaggerFileConfiguration();
+
+            foreach (var file in files)
+            {
+                if (files.Count > 1 && file.Name.Equals(primaryConfigFile, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var lines = File.ReadAllText(file.FullName);
+
+                var config = JsonConvert.DeserializeObject<SwaggerFileConfiguration>(lines);
+
+                if (file.Name.Equals(globalConfigFile, StringComparison.OrdinalIgnoreCase))
+                {
+                    fileConfiguration.GlobalConfiguration = config.GlobalConfiguration;
+                }
+
+                if (file.Name.Equals(SwaggerEndPointsConfigFile, StringComparison.OrdinalIgnoreCase))
+                {
+                    fileConfiguration.SwaggerEndPoints = config.SwaggerEndPoints;
+                }
+
+                fileConfiguration.Aggregates.AddRange(config.Aggregates);
+                fileConfiguration.ReRoutes.AddRange(config.ReRoutes);
+            }
+
+            var json = JsonConvert.SerializeObject(fileConfiguration);
+
+            File.WriteAllText(primaryConfigFile, json);
+
+            builder.AddJsonFile(primaryConfigFile, false, false);
+
+            return builder;
+        }
+
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -67,6 +67,5 @@ namespace MMLib.SwaggerForOcelot.DependencyInjection
 
             return builder;
         }
-
     }
 }


### PR DESCRIPTION
Adding SwaggerFileReRoute to replace Ocelot FileReRoute with SwaggerKey property.
Adding SwaggerFileConfiguration to replace Ocelot FileConfiguration use SwaggerFileReRoute in ReRoutes property.
Adding Extension method AddOcelotWithSwaggerSupport to replace AddOcelot.

Missing unit tests.  They should follow same pattern as: https://github.com/ThreeMammals/Ocelot/blob/master/test/Ocelot.UnitTests/DependencyInjection/ConfigurationBuilderExtensionsTests.cs

Missing usage documentation.  Needs to explain that this requires the SwaggerEndPoints be in a file named "ocelot.SwaggerEndPoints.json".