### PR TITLE
* Fixed the routes when the apigateway is not published in the root of a site overwriting the swagger server field and making the calls to the microservices not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ app.UseSwaggerForOcelotUI(Configuration, opt => {
     opts.ReConfigureUpstreamSwaggerJson = AlterUpstreamSwaggerJson;
 })
   ```
+You can optionally customize the swagger server prior to calling the endpoints of the microservices as follows:
+```CSharp
+app.UseSwaggerForOcelotUI(Configuration, opt => {
+    opts.ReConfigureUpstreamSwaggerJson = AlterUpstreamSwaggerJson;
+	opts.ServerOcelot = "/siteName/apigateway" ;
+})
+  ```
 
 7. Show your microservices interactive documentation.
 

--- a/demo/ApiGateway/Startup.cs
+++ b/demo/ApiGateway/Startup.cs
@@ -59,6 +59,7 @@ namespace ApiGateway
                         new KeyValuePair<string, string>("Key", "Value"),
                         new KeyValuePair<string, string>("Key2", "Value2"),
                     };
+                    opt.UseServerSwagger = false;
                 })
                 .UseOcelot()
                 .Wait();

--- a/demo/ApiGateway/Startup.cs
+++ b/demo/ApiGateway/Startup.cs
@@ -59,7 +59,8 @@ namespace ApiGateway
                         new KeyValuePair<string, string>("Key", "Value"),
                         new KeyValuePair<string, string>("Key2", "Value2"),
                     };
-                    opt.UseServerSwagger = false;
+
+                    opt.ServerOcelot = "/siteName/apigateway" ;
                 })
                 .UseOcelot()
                 .Wait();

--- a/demo/ApiGateway/ocelot.json
+++ b/demo/ApiGateway/ocelot.json
@@ -1,29 +1,116 @@
 {
   "ReRoutes": [
     {
-      "DownstreamPathTemplate": "/satcen/apitsr/{everything}",
+      "DownstreamPathTemplate": "/api/{everything}",
+      "ServiceName": "contacts",
+      "UpstreamPathTemplate": "/api/contacts/{everything}",
+      "UpstreamHttpMethod": [ "Get" ],
+      "SwaggerKey": "contacts"
+    },
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
+      "ServiceName": "projects",
+      "UpstreamPathTemplate": "/api/projects/{everything}",
+      "SwaggerKey": "projects"
+    },
+    {
+      "DownstreamPathTemplate": "/{everything}",
+      "ServiceName": "pets",
+      "UpstreamHttpMethod": [ "Get", "Post" ],
+      "UpstreamPathTemplate": "/api/pets/{everything}",
+      "SwaggerKey": "pets"
+    },
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
       "DownstreamScheme": "http",
-      "DownstreamHostAndPorts": [
-        {
-          "Host": "172.30.9.200",
-          "Port": 8080
-        }
-      ],
-      "UpstreamPathTemplate": "/api/request/{everything}",
-      "DangerousAcceptAnyServerCertificateValidator": true,
-      "SwaggerKey": "request"
+      "ServiceName": "orders",
+      "UpstreamPathTemplate": "/api/orders/{everything}",
+      "UpstreamHttpMethod": [],
+      "SwaggerKey": "orders"
     }
   ],
   "SwaggerEndPoints": [
     {
-      "Key": "request",
+      "Key": "contacts",
       "Config": [
         {
-          "Name": "ApiIngestTSR API",
+          "Name": "Contacts API",
           "Version": "v1",
-          "Url": "http://172.30.9.200:8080/swagger/v1/swagger.json"
+          "Service": {
+            "Name": "contacts",
+            "Path": "/swagger/v1/swagger.json"
+          }
+        }
+      ]
+    },
+    {
+      "Key": "gateway",
+      "TransformByOcelotConfig": false,
+      "Config": [
+        {
+          "Name": "Gateway",
+          "Version": "v1",
+          "Url": "http://localhost:5000/swagger/v1/swagger.json"
+        }
+      ]
+    },
+    {
+      "Key": "projects",
+      "Config": [
+        {
+          "Name": "Projects API",
+          "Version": "v1",
+          "Service": {
+            "Name": "projects",
+            "Path": "/swagger/v1/swagger.json"
+          }
+        }
+      ]
+    },
+    {
+      "Key": "pets",
+      "Config": [
+        {
+          "Name": "Pets API",
+          "Version": "v1",
+          "Service": {
+            "Name": "projects",
+            "Path": "/swagger/v1/swagger.json"
+          }
+        }
+      ]
+    },
+    {
+      "Key": "orders",
+      "Config": [
+        {
+          "Name": "Orders API",
+          "Version": "v0.9",
+          "Url": "http://localhost:5400/swagger/v0.9/swagger.json"
+        },
+        {
+          "Name": "Orders API",
+          "Version": "v1",
+          "Url": "http://localhost:5400/swagger/v1/swagger.json"
+        },
+        {
+          "Name": "Orders API",
+          "Version": "v2",
+          "Url": "http://localhost:5400/swagger/v2/swagger.json"
+        },
+        {
+          "Name": "Orders API",
+          "Version": "v3",
+          "Url": "http://localhost:5400/swagger/v3/swagger.json"
         }
       ]
     }
-  ]
+  ],
+  "GlobalConfiguration": {
+    "BaseUrl": "http://localhost",
+    "ServiceDiscoveryProvider": {
+      "Type": "AppConfiguration",
+      "PollingIntervalSeconds": 10000
+    }
+  }
 }

--- a/demo/ApiGateway/ocelot.json
+++ b/demo/ApiGateway/ocelot.json
@@ -1,116 +1,29 @@
 {
   "ReRoutes": [
     {
-      "DownstreamPathTemplate": "/api/{everything}",
-      "ServiceName": "contacts",
-      "UpstreamPathTemplate": "/api/contacts/{everything}",
-      "UpstreamHttpMethod": [ "Get" ],
-      "SwaggerKey": "contacts"
-    },
-    {
-      "DownstreamPathTemplate": "/api/{everything}",
-      "ServiceName": "projects",
-      "UpstreamPathTemplate": "/api/projects/{everything}",
-      "SwaggerKey": "projects"
-    },
-    {
-      "DownstreamPathTemplate": "/{everything}",
-      "ServiceName": "pets",
-      "UpstreamHttpMethod": [ "Get", "Post" ],
-      "UpstreamPathTemplate": "/api/pets/{everything}",
-      "SwaggerKey": "pets"
-    },
-    {
-      "DownstreamPathTemplate": "/api/{everything}",
+      "DownstreamPathTemplate": "/satcen/apitsr/{everything}",
       "DownstreamScheme": "http",
-      "ServiceName": "orders",
-      "UpstreamPathTemplate": "/api/orders/{everything}",
-      "UpstreamHttpMethod": [],
-      "SwaggerKey": "orders"
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "172.30.9.200",
+          "Port": 8080
+        }
+      ],
+      "UpstreamPathTemplate": "/api/request/{everything}",
+      "DangerousAcceptAnyServerCertificateValidator": true,
+      "SwaggerKey": "request"
     }
   ],
   "SwaggerEndPoints": [
     {
-      "Key": "contacts",
+      "Key": "request",
       "Config": [
         {
-          "Name": "Contacts API",
+          "Name": "ApiIngestTSR API",
           "Version": "v1",
-          "Service": {
-            "Name": "contacts",
-            "Path": "/swagger/v1/swagger.json"
-          }
-        }
-      ]
-    },
-    {
-      "Key": "gateway",
-      "TransformByOcelotConfig": false,
-      "Config": [
-        {
-          "Name": "Gateway",
-          "Version": "v1",
-          "Url": "http://localhost:5000/swagger/v1/swagger.json"
-        }
-      ]
-    },
-    {
-      "Key": "projects",
-      "Config": [
-        {
-          "Name": "Projects API",
-          "Version": "v1",
-          "Service": {
-            "Name": "projects",
-            "Path": "/swagger/v1/swagger.json"
-          }
-        }
-      ]
-    },
-    {
-      "Key": "pets",
-      "Config": [
-        {
-          "Name": "Pets API",
-          "Version": "v1",
-          "Service": {
-            "Name": "projects",
-            "Path": "/swagger/v1/swagger.json"
-          }
-        }
-      ]
-    },
-    {
-      "Key": "orders",
-      "Config": [
-        {
-          "Name": "Orders API",
-          "Version": "v0.9",
-          "Url": "http://localhost:5400/swagger/v0.9/swagger.json"
-        },
-        {
-          "Name": "Orders API",
-          "Version": "v1",
-          "Url": "http://localhost:5400/swagger/v1/swagger.json"
-        },
-        {
-          "Name": "Orders API",
-          "Version": "v2",
-          "Url": "http://localhost:5400/swagger/v2/swagger.json"
-        },
-        {
-          "Name": "Orders API",
-          "Version": "v3",
-          "Url": "http://localhost:5400/swagger/v3/swagger.json"
+          "Url": "http://172.30.9.200:8080/swagger/v1/swagger.json"
         }
       ]
     }
-  ],
-  "GlobalConfiguration": {
-    "BaseUrl": "http://localhost",
-    "ServiceDiscoveryProvider": {
-      "Type": "AppConfiguration",
-      "PollingIntervalSeconds": 10000
-    }
-  }
+  ]
 }

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -40,6 +40,6 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// <summary>
         /// Configure if use Server of swagger or not
         /// </summary>
-        public bool UseServerSwagger { get; set; } = true;
+        public string ServerOcelot { get; set; }
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -38,7 +38,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
         public Func<HttpContext, string, Task<string>> ReConfigureUpstreamSwaggerJsonAsync { get; set; }
 
         /// <summary>
-        /// Configure if use Server of swagger or not
+        /// Configure route of server of swagger in ocelot
         /// </summary>
         public string ServerOcelot { get; set; }
     }

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -28,17 +28,17 @@ namespace MMLib.SwaggerForOcelot.Configuration
         public IEnumerable<KeyValuePair<string, string>> DownstreamSwaggerHeaders { get; set; }
 
         /// <summary>
-        /// Alter swagger/openApi json after it has been transformed
+        /// Alter swagger/openApi json after it has been transformed.
         /// </summary>
         public Func<HttpContext, string, string> ReConfigureUpstreamSwaggerJson { get; set; }
 
         /// <summary>
-        /// Alter swagger/openApi json after it has been transformed
+        /// Alter swagger/openApi json after it has been transformed.
         /// </summary>
         public Func<HttpContext, string, Task<string>> ReConfigureUpstreamSwaggerJsonAsync { get; set; }
 
         /// <summary>
-        /// Configure route of server of swagger in ocelot
+        /// Configure route of server of swagger in ocelot.
         /// </summary>
         public string ServerOcelot { get; set; }
     }

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -36,5 +36,10 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// Alter swagger/openApi json after it has been transformed
         /// </summary>
         public Func<HttpContext, string, Task<string>> ReConfigureUpstreamSwaggerJsonAsync { get; set; }
+
+        /// <summary>
+        /// Configure if use Server of swagger or not
+        /// </summary>
+        public bool UseServerSwagger { get; set; } = true;
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -67,14 +67,19 @@ namespace MMLib.SwaggerForOcelot.Middleware
             HttpClient httpClient = _httpClientFactory.CreateClient();
             AddHeaders(httpClient);
             string content = await httpClient.GetStringAsync(Url);
-            string hostName = EndPoint.HostOverride ?? context.Request.Host.Value.RemoveSlashFromEnd();
+            string serverName;
+            if (string.IsNullOrWhiteSpace(_options.ServerOcelot))
+                serverName = EndPoint.HostOverride ?? context.Request.Host.Value.RemoveSlashFromEnd();
+            else
+                serverName = _options.ServerOcelot;
+
             IEnumerable<ReRouteOptions> reRouteOptions = _reRoutes.Value
                 .ExpandConfig(EndPoint)
                 .GroupByPaths();
 
             if (EndPoint.TransformByOcelotConfig)
             {
-                content = _transformer.Transform(content, reRouteOptions, _options.UseServerSwagger, hostName);
+                content = _transformer.Transform(content, reRouteOptions, serverName);
             }
             content = await ReconfigureUpstreamSwagger(context, content);
 

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -74,7 +74,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
 
             if (EndPoint.TransformByOcelotConfig)
             {
-                content = _transformer.Transform(content, reRouteOptions, hostName);
+                content = _transformer.Transform(content, reRouteOptions, _options.UseServerSwagger, hostName);
             }
             content = await ReconfigureUpstreamSwagger(context, content);
 

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -69,9 +69,13 @@ namespace MMLib.SwaggerForOcelot.Middleware
             string content = await httpClient.GetStringAsync(Url);
             string serverName;
             if (string.IsNullOrWhiteSpace(_options.ServerOcelot))
+            {
                 serverName = EndPoint.HostOverride ?? context.Request.Host.Value.RemoveSlashFromEnd();
+            }
             else
+            {
                 serverName = _options.ServerOcelot;
+            }
 
             IEnumerable<ReRouteOptions> reRouteOptions = _reRoutes.Value
                 .ExpandConfig(EndPoint)

--- a/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
@@ -17,6 +17,6 @@ namespace MMLib.SwaggerForOcelot.Transformation
         /// <returns>
         /// Transformed swagger json.
         /// </returns>
-        string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, string hostOverride);
+        string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, bool useServer, string hostOverride);
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
@@ -13,10 +13,10 @@ namespace MMLib.SwaggerForOcelot.Transformation
         /// </summary>
         /// <param name="swaggerJson">The swagger json.</param>
         /// <param name="reRoutes">The re routes.</param>
-        /// <param name="hostOverride">The host override to add to swagger json.</param>
+        /// <param name="serverOverride">The host override to add to swagger json.</param>
         /// <returns>
         /// Transformed swagger json.
         /// </returns>
-        string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, bool useServer, string hostOverride);
+        string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, string serverOverride);
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -73,7 +73,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
             return swagger.ToString(Formatting.Indented);
         }
 
-        private string TransformOpenApi(JObject openApi, IEnumerable<ReRouteOptions> reRoutes, string serverOverride = null)
+        private string TransformOpenApi(JObject openApi, IEnumerable<ReRouteOptions> reRoutes, string serverOverride = "/")
         {
             // NOTE: Only supporting one server for now.
             string downstreamBasePath = "";
@@ -263,7 +263,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
             {
                 if (server[OpenApiProperties.Url] != null)
                 {
-                    server[OpenApiProperties.Url] = serverOverride;
+                    server[OpenApiProperties.Url] = serverOverride.RemoveSlashFromEnd();
                 }
             }
         }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -73,12 +73,14 @@ namespace MMLib.SwaggerForOcelot.Tests
                 .Setup(x => x.Transform(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<ReRouteOptions>>(),
+                    It.IsAny<bool>(),
                     It.IsAny<string>()))
                 .Returns((
                     string swaggerJson,
                     IEnumerable<ReRouteOptions> reRouteOptions,
+                    bool userServer,
                     string hostOverride) => new SwaggerJsonTransformer()
-                    .Transform(swaggerJson,reRouteOptions,hostOverride));
+                    .Transform(swaggerJson,reRouteOptions, userServer, hostOverride));
             var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
                 next.Invoke,
                 swaggerForOcelotOptions,
@@ -100,6 +102,7 @@ namespace MMLib.SwaggerForOcelot.Tests
             swaggerJsonTransformerMock.Verify(x => x.Transform(
                 It.IsAny<string>(),
                 It.IsAny<IEnumerable<ReRouteOptions>>(),
+                It.IsAny<bool>(),
                 It.IsAny<string>()), Times.Once);
         }
 
@@ -320,7 +323,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                 _transformedJson = transformedJson;
             }
 
-            public string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, string hostOverride)
+            public string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, bool useServer, string hostOverride)
             {
                 return _transformedJson;
             }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -73,14 +73,12 @@ namespace MMLib.SwaggerForOcelot.Tests
                 .Setup(x => x.Transform(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<ReRouteOptions>>(),
-                    It.IsAny<bool>(),
                     It.IsAny<string>()))
                 .Returns((
                     string swaggerJson,
                     IEnumerable<ReRouteOptions> reRouteOptions,
-                    bool userServer,
-                    string hostOverride) => new SwaggerJsonTransformer()
-                    .Transform(swaggerJson,reRouteOptions, userServer, hostOverride));
+                    string serverOverride) => new SwaggerJsonTransformer()
+                    .Transform(swaggerJson,reRouteOptions, serverOverride));
             var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
                 next.Invoke,
                 swaggerForOcelotOptions,
@@ -102,7 +100,6 @@ namespace MMLib.SwaggerForOcelot.Tests
             swaggerJsonTransformerMock.Verify(x => x.Transform(
                 It.IsAny<string>(),
                 It.IsAny<IEnumerable<ReRouteOptions>>(),
-                It.IsAny<bool>(),
                 It.IsAny<string>()), Times.Once);
         }
 
@@ -323,7 +320,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                 _transformedJson = transformedJson;
             }
 
-            public string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, bool useServer, string hostOverride)
+            public string Transform(string swaggerJson, IEnumerable<ReRouteOptions> reRoutes, string serverOverride)
             {
                 return _transformedJson;
             }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using JsonDiffPatchDotNet;
 using MMLib.SwaggerForOcelot.Transformation;
 using Newtonsoft.Json.Linq;
@@ -22,6 +22,7 @@ namespace MMLib.SwaggerForOcelot.Tests
             string transformed = transformer.Transform(
                 testData.DownstreamSwagger.ToString(),
                 testData.ReRoutes,
+                true,
                 testData.HostOverride);
 
             AreEqual(transformed, testData.ExpectedTransformedSwagger);

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
@@ -22,7 +22,6 @@ namespace MMLib.SwaggerForOcelot.Tests
             string transformed = transformer.Transform(
                 testData.DownstreamSwagger.ToString(),
                 testData.ReRoutes,
-                true,
                 testData.HostOverride);
 
             AreEqual(transformed, testData.ExpectedTransformedSwagger);


### PR DESCRIPTION
when this nuget is used in a site, in the root of that site it works correctly but if you add a site and later several applications hanging from that site gives problems because of the swagger server field, I have made a change that allows to configure the swagger server and so allow it to work in multiple levels.


