### PR TITLE
Allow programmatic configuration of SwaggerEndpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ services.AddSwaggerForOcelot(Configuration);
 6. In `Configure` method, insert the `SwaggerForOcelot` middleware to expose interactive documentation.
 
 ```CSharp
-app.UseSwaggerForOcelotUI(Configuration, opt => {
+app.UseSwaggerForOcelotUI(opt => {
   opt.PathToSwaggerGenerator = "/swagger/docs";
 })
 ```
@@ -108,7 +108,7 @@ app.UseSwaggerForOcelotUI(Configuration, opt => {
    You can optionally include headers that your Ocelot Gateway will send when requesting a swagger endpoint. This can be especially useful if your downstream microservices require contents from a header to authenticate.
 
   ```CSharp
-app.UseSwaggerForOcelotUI(Configuration, opt => {
+app.UseSwaggerForOcelotUI(opt => {
     opts.DownstreamSwaggerHeaders = new[]
     {
         new KeyValuePair<string, string>("Auth-Key", "AuthValue"),
@@ -126,13 +126,13 @@ public string AlterUpstreamSwaggerJson(HttpContext context, string swaggerJson)
     return swagger.ToString(Formatting.Indented);
 }
 
-app.UseSwaggerForOcelotUI(Configuration, opt => {
+app.UseSwaggerForOcelotUI(opt => {
     opts.ReConfigureUpstreamSwaggerJson = AlterUpstreamSwaggerJson;
 })
   ```
 You can optionally customize the swagger server prior to calling the endpoints of the microservices as follows:
 ```CSharp
-app.UseSwaggerForOcelotUI(Configuration, opt => {
+app.UseSwaggerForOcelotUI(opt => {
     opts.ReConfigureUpstreamSwaggerJson = AlterUpstreamSwaggerJson;
 	opts.ServerOcelot = "/siteName/apigateway" ;
 })

--- a/demo/ApiGateway/Startup.cs
+++ b/demo/ApiGateway/Startup.cs
@@ -52,7 +52,7 @@ namespace ApiGateway
                 endpoints.MapControllers();
             });
             app.UseStaticFiles();
-            app.UseSwaggerForOcelotUI(Configuration,  opt =>
+            app.UseSwaggerForOcelotUI(opt =>
                 {
                     opt.DownstreamSwaggerHeaders = new[]
                     {

--- a/demo/ApiGatewayWithPath/Startup.cs
+++ b/demo/ApiGatewayWithPath/Startup.cs
@@ -35,7 +35,7 @@ namespace ApiGatewayWithPath
                 app.UseDeveloperExceptionPage();
             }
             app.UseStaticFiles();
-            app.UseSwaggerForOcelotUI(Configuration, opt =>
+            app.UseSwaggerForOcelotUI(opt =>
             {
                 opt.DownstreamSwaggerEndPointBasePath = "/gateway/swagger/docs";
                 opt.PathToSwaggerGenerator = "/swagger/docs";

--- a/tests/MMLib.SwaggerForOcelot.Tests/BuilderExtensionsShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/BuilderExtensionsShould.cs
@@ -2,16 +2,35 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using MMLib.SwaggerForOcelot.Configuration;
+using Newtonsoft.Json.Linq;
+using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
+using System.Collections.Generic;
 using System.IO;
-using Newtonsoft.Json;
+using System.Linq;
 using Xunit;
 
 namespace MMLib.SwaggerForOcelot.Tests
 {
     public class BuilderExtensionsShould
     {
+        private const string TestEndpointUrl = "http://localhost:5100/swagger/v1/swagger.json";
+        private static readonly SwaggerEndPointOptions _testSwaggerEndpointOptions = new SwaggerEndPointOptions
+        {
+            Key = "contacts",
+            Config = new List<SwaggerEndPointConfig>
+            {
+                new SwaggerEndPointConfig
+                {
+                    Name = "Contacts API",
+                    Version = "v1",
+                    Url = TestEndpointUrl,
+                },
+            },
+        };
+
         [Fact]
         public void ThrowWhenSwaggerEndPointsSectionIsMissing() => TestWithInvalidConfiguration("{}");
 
@@ -19,11 +38,52 @@ namespace MMLib.SwaggerForOcelot.Tests
         public void ThrowWhenSwaggerEndPointsSectionIsEmpty()
             => TestWithInvalidConfiguration($"{{\"{SwaggerEndPointOptions.ConfigurationSectionName}\":[]}}");
 
-        private void TestWithInvalidConfiguration(string jsonConfiguration)
+        [Fact]
+        public void UseSwaggerEndpointsFromConfigurationFile()
+        {
+            var configJson = new JObject
+            {
+                [SwaggerEndPointOptions.ConfigurationSectionName] = new JArray
+                {
+                    JObject.FromObject(_testSwaggerEndpointOptions),
+                },
+            };
+
+            TestWithValidConfiguration(configJson.ToString());
+        }
+
+        [Fact]
+        public void UseSwaggerEndpointsFromProgrammaticConfiguration()
+        {
+            void configureServices(IServiceCollection services)
+            {
+                services.Configure<List<SwaggerEndPointOptions>>(options =>
+                {
+                    options.Add(_testSwaggerEndpointOptions);
+                });
+            }
+
+            TestWithValidConfiguration("{}", configureServices);
+        }
+
+        private void TestWithValidConfiguration(string jsonConfiguration, Action<IServiceCollection> configureServices = null)
+        {
+            IApplicationBuilder builder = GetApplicationBuilderWithJsonConfiguration(jsonConfiguration, configureServices);
+            Action action = () => builder.UseSwaggerForOcelotUI();
+
+            action.Should().NotThrow();
+        }
+
+        private IApplicationBuilder GetApplicationBuilderWithJsonConfiguration(string jsonConfiguration, Action<IServiceCollection> configureServices = null)
         {
             IConfiguration config = GetConfiguration(jsonConfiguration);
-            IApplicationBuilder builder = GetApplicationBuilder(config);
-            Action action = () => { builder.UseSwaggerForOcelotUI(config); };
+            return GetApplicationBuilder(config, configureServices);
+        }
+
+        private void TestWithInvalidConfiguration(string jsonConfiguration)
+        {
+            IApplicationBuilder builder = GetApplicationBuilderWithJsonConfiguration(jsonConfiguration);
+            Action action = () => builder.UseSwaggerForOcelotUI();
 
             action.Should().Throw<InvalidOperationException>();
         }
@@ -38,9 +98,13 @@ namespace MMLib.SwaggerForOcelot.Tests
             return configuration;
         }
 
-        private IApplicationBuilder GetApplicationBuilder(IConfiguration configuration)
+        private IApplicationBuilder GetApplicationBuilder(IConfiguration configuration, Action<IServiceCollection> configureServices = null)
         {
-            IServiceProvider serviceProvider = new ServiceCollection().AddSwaggerForOcelot(configuration).BuildServiceProvider();
+            IServiceCollection serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSwaggerForOcelot(configuration);
+            configureServices?.Invoke(serviceCollection);
+            IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
 
             return new ApplicationBuilder(serviceProvider);
         }


### PR DESCRIPTION
Use configured options in UseSwaggerForOcelotUI to allow programmatic configuration of services.

Overloads of UseSwaggerForOcelotUI with IConfiguration parameter become deprecated.

Fixes #104


