### PR TITLE
Respect the DownstreamHttpVersion

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Configuration/ReRouteOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/ReRouteOptions.cs
@@ -80,6 +80,11 @@ namespace MMLib.SwaggerForOcelot.Configuration
         public string DownstreamScheme { get; set; }
 
         /// <summary>
+        /// Downstream Http Version.
+        /// </summary>
+        public string DownstreamHttpVersion { get; set; }
+
+        /// <summary>
         /// Gets or sets the upstream HTTP method.
         /// </summary>
         public IEnumerable<string> UpstreamHttpMethod { get; set; }

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -70,12 +70,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
                 .GroupByPaths();
 
             HttpClient httpClient = _httpClientFactory.CreateClient();
-            string downstreamHttpVersion = reRouteOptions.FirstOrDefault()?.DownstreamHttpVersion;
-            if (downstreamHttpVersion != null)
-            {
-                int[] version = downstreamHttpVersion.Split('.').Select(int.Parse).ToArray();
-                httpClient.DefaultRequestVersion = new Version(version[0], version[1]);
-            }
+            SetHttpVersion(httpClient, reRouteOptions);
             AddHeaders(httpClient);
             string content = await httpClient.GetStringAsync(Url);
             string serverName;
@@ -129,6 +124,16 @@ namespace MMLib.SwaggerForOcelot.Middleware
             foreach (KeyValuePair<string, string> kvp in _options.DownstreamSwaggerHeaders)
             {
                 httpClient.DefaultRequestHeaders.Add(kvp.Key, kvp.Value);
+            }
+        }
+
+        private void SetHttpVersion(HttpClient httpClient, IEnumerable<ReRouteOptions> reRouteOptions)
+        {
+            string downstreamHttpVersion = reRouteOptions.FirstOrDefault()?.DownstreamHttpVersion;
+            if (downstreamHttpVersion != null)
+            {
+                int[] version = downstreamHttpVersion.Split('.').Select(int.Parse).ToArray();
+                httpClient.DefaultRequestVersion = new Version(version[0], version[1]);
             }
         }
 

--- a/src/MMLib.SwaggerForOcelot/ReRouteOptionsExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/ReRouteOptionsExtensions.cs
@@ -23,7 +23,10 @@ namespace MMLib.SwaggerForOcelot
                     route.UpstreamPathTemplate,
                     route.DownstreamPathTemplate,
                     p.Key.VirtualDirectory,
-                    p.Where(r => r.UpstreamHttpMethod != null).SelectMany(r => r.UpstreamHttpMethod));
+                    p.Where(r => r.UpstreamHttpMethod != null).SelectMany(r => r.UpstreamHttpMethod))
+                {
+                    DownstreamHttpVersion = route.DownstreamHttpVersion
+                };
             });
 
         /// <summary>
@@ -58,7 +61,8 @@ namespace MMLib.SwaggerForOcelot
                     UpstreamPathTemplate =
                         reRouteOption.UpstreamPathTemplate.Replace(endPoint.VersionPlaceholder,
                             c.Version),
-                    VirtualDirectory = reRouteOption.VirtualDirectory
+                    VirtualDirectory = reRouteOption.VirtualDirectory,
+                    DownstreamHttpVersion = reRouteOption.DownstreamHttpVersion
                 });
                 reRouteOptions.AddRange(versionMappedReRouteOptions);
             }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -147,6 +147,62 @@ namespace MMLib.SwaggerForOcelot.Tests
             AreEqual(transformedUpstreamSwagger, upstreamSwagger);
         }
 
+        [Fact]
+        public async Task RespectDownstreamHttpVersionRouteSetting()
+        {
+            // Arrange
+            const string version = "v1";
+            const string key = "projects";
+            HttpContext httpContext = GetHttpContext(requestPath: $"/{version}/{key}");
+
+            var next = new TestRequestDelegate();
+
+            // What is being tested
+            var swaggerForOcelotOptions = new SwaggerForOcelotUIOptions();
+            TestSwaggerEndpointOptions swaggerEndpointOptions = CreateSwaggerEndpointOptions(key,version);
+            var rerouteOptions = new TestReRouteOptions(new List<ReRouteOptions>
+            {
+                new ReRouteOptions
+                {
+                    SwaggerKey = "projects",
+                    UpstreamPathTemplate = "/api/projects/Projects",
+                    DownstreamPathTemplate = "/api/Projects",
+                    DownstreamHttpVersion = "2.0",
+                }
+            });
+
+            // downstreamSwagger is returned when client.GetStringAsync is called by the middleware.
+            string downstreamSwagger = await GetBaseOpenApi("OpenApiWithVersionPlaceholderBase");
+            HttpClient httClientMock = GetHttpClient(downstreamSwagger);
+            var httpClientFactory = new TestHttpClientFactory(httClientMock);
+
+            var swaggerJsonTransformerMock = new Mock<ISwaggerJsonTransformer>();
+            swaggerJsonTransformerMock
+                .Setup(x => x.Transform(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<ReRouteOptions>>(),
+                    It.IsAny<string>()))
+                .Returns((
+                    string swaggerJson,
+                    IEnumerable<ReRouteOptions> reRouteOptions,
+                    string serverOverride) => new SwaggerJsonTransformer()
+                    .Transform(swaggerJson,reRouteOptions, serverOverride));
+            var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
+                next.Invoke,
+                swaggerForOcelotOptions,
+                rerouteOptions,
+                swaggerEndpointOptions,
+                httpClientFactory,
+                swaggerJsonTransformerMock.Object);
+
+            // Act
+            await swaggerForOcelotMiddleware.Invoke(httpContext, DummySwaggerServiceDiscoveryProvider.Default);
+            httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+
+            // Assert
+            httClientMock.DefaultRequestVersion.Should().BeEquivalentTo(new Version(2, 0));
+        }
+
         private TestSwaggerEndpointOptions CreateSwaggerEndpointOptions(string key, string version)
             => new TestSwaggerEndpointOptions(
                 new List<SwaggerEndPointOptions>()


### PR DESCRIPTION
Ocelot has a recently added Route configuration called "DownstreamHttpVersion".  See [documentation](https://ocelot.readthedocs.io/en/latest/features/configuration.html?highlight=http%2F2#downstreamhttpversion).  This updates the `SwaggerForOcelotMiddleware` to respect this setting when getting the swagger.json from the downstream.


