### PR TITLE
Ensure the host in the transformed swagger json does not have a scheme

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -1,10 +1,10 @@
 ﻿using Kros.IO;
 using MMLib.SwaggerForOcelot.Configuration;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
 
 namespace MMLib.SwaggerForOcelot.Transformation
 {
@@ -222,6 +222,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
 
         private static void AddHost(JObject swagger, string swaggerHost)
         {
+            swaggerHost = swaggerHost.Contains(Uri.SchemeDelimiter) ? new Uri(swaggerHost).Authority : swaggerHost;
             swagger.Add(SwaggerProperties.Host, swaggerHost);
         }
 

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Tests\BasicConfigurationWithSchemaInHostOverride.json" />
     <None Remove="Tests\Issue_65.json" />
   </ItemGroup>
   <ItemGroup>
@@ -11,6 +12,7 @@
     <EmbeddedResource Include="Resources\OpenApiWithVersionPlaceholderBaseTransformed.json" />
     <EmbeddedResource Include="Resources\OpenApiBase.json" />
     <EmbeddedResource Include="Resources\OpenApiBaseTransformed.json" />
+    <EmbeddedResource Include="Tests\BasicConfigurationWithSchemaInHostOverride.json" />
 
     <EmbeddedResource Include="Tests\BasicConfiguration.json" />
 

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using JsonDiffPatchDotNet;
+﻿using JsonDiffPatchDotNet;
 using MMLib.SwaggerForOcelot.Transformation;
 using Newtonsoft.Json.Linq;
+using System;
 using Xunit;
 using Xunit.Sdk;
 
@@ -24,10 +24,10 @@ namespace MMLib.SwaggerForOcelot.Tests
                 testData.Routes,
                 testData.HostOverride);
 
-            AreEqual(transformed, testData.ExpectedTransformedSwagger);
+            AreEqual(transformed, testData.ExpectedTransformedSwagger, testData.FileName);
         }
 
-        private static void AreEqual(string transformed, JObject expected)
+        private static void AreEqual(string transformed, JObject expected, string filename)
         {
             var actual = JObject.Parse(transformed);
 
@@ -37,7 +37,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                 JToken patch = jdp.Diff(actual, expected);
 
                 throw new XunitException(
-                    $"Transformed upstream swagger is not equal to expected. {Environment.NewLine} Diff: {patch}");
+                    $"Transformed upstream swagger is not equal to expected.{Environment.NewLine}File: {filename}. {Environment.NewLine}Diff: {patch}");
             }
         }
     }

--- a/tests/MMLib.SwaggerForOcelot.Tests/Tests/BasicConfigurationWithSchemaInHostOverride.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Tests/BasicConfigurationWithSchemaInHostOverride.json
@@ -1,0 +1,355 @@
+{
+    "name": "Basic configuration",
+    "description": "According to the swagger specification the scheme should never be included in the host. See https://github.com/Burgyn/MMLib.SwaggerForOcelot/issues/117 and https://swagger.io/docs/specification/2-0/api-host-and-base-path/",
+    "hostOverride": "https://localhost:8000",
+    "routes": [
+        {
+            "DownstreamPathTemplate": "/api/{everything}",
+            "UpstreamPathTemplate": "/api/projects/{everything}",
+            "SwaggerKey": "projects"
+        }
+    ],
+    "downstreamSwagger": {
+        "swagger": "2.0",
+        "info": {
+            "version": "v1",
+            "title": "Projects API"
+        },
+        "basePath": "/",
+        "paths": {
+            "/api/Projects": {
+                "get": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "uniqueItems": false,
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/Project"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/api/Projects/{id}": {
+                "get": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "$ref": "#/definitions/Project"
+                            }
+                        },
+                        "404": {
+                            "description": "Not Found"
+                        }
+                    }
+                }
+            },
+            "/api/Projects/projectCreate": {
+                "post": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "CreateProject",
+                    "consumes": [
+                        "application/json-patch+json",
+                        "application/json",
+                        "text/json",
+                        "application/*+json"
+                    ],
+                    "produces": [],
+                    "parameters": [
+                        {
+                            "name": "projectViewModel",
+                            "in": "body",
+                            "required": false,
+                            "schema": {
+                                "$ref": "#/definitions/ProjectViewModel"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "201": {
+                            "description": "Success"
+                        },
+                        "400": {
+                            "description": "Bad Request"
+                        }
+                    }
+                }
+            },
+            "/api/Values": {
+                "get": {
+                    "tags": [
+                        "Values"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "uniqueItems": false,
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "definitions": {
+            "Project": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "owner": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ProjectViewModel": {
+                "required": [
+                    "name",
+                    "owner"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 50,
+                        "type": "string"
+                    },
+                    "description": {
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "owner": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
+    "expectedTransformedSwagger": {
+        "swagger": "2.0",
+        "info": {
+            "version": "v1",
+            "title": "Projects API"
+        },
+        "basePath": "/",
+        "paths": {
+            "/api/projects/Projects": {
+                "get": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "uniqueItems": false,
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/Project"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/api/projects/Projects/{id}": {
+                "get": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "$ref": "#/definitions/Project"
+                            }
+                        },
+                        "404": {
+                            "description": "Not Found"
+                        }
+                    }
+                }
+            },
+            "/api/projects/Projects/projectCreate": {
+                "post": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "CreateProject",
+                    "consumes": [
+                        "application/json-patch+json",
+                        "application/json",
+                        "text/json",
+                        "application/*+json"
+                    ],
+                    "produces": [],
+                    "parameters": [
+                        {
+                            "name": "projectViewModel",
+                            "in": "body",
+                            "required": false,
+                            "schema": {
+                                "$ref": "#/definitions/ProjectViewModel"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "201": {
+                            "description": "Success"
+                        },
+                        "400": {
+                            "description": "Bad Request"
+                        }
+                    }
+                }
+            },
+            "/api/projects/Values": {
+                "get": {
+                    "tags": [
+                        "Values"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "uniqueItems": false,
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "definitions": {
+            "Project": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "format": "int32",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "owner": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ProjectViewModel": {
+                "required": [
+                    "name",
+                    "owner"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 50,
+                        "type": "string"
+                    },
+                    "description": {
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "owner": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "host": "localhost:8000"
+    }
+}


### PR DESCRIPTION
This PR fixes #117 and is based on the idea provider by natiox here https://github.com/Burgyn/MMLib.SwaggerForOcelot/issues/117#issuecomment-667202004

But instead of always using "new Uri" I check if there is a scheme delimiter first - because of some weirdness I encountered while testing with URI's that did not have a scheme defined.