### PR TITLE
Add support for filename

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,3 +19,5 @@ template: |
   ## Changes
 
   $CHANGES
+
+  Did this project help you? [You can now buy me a beer 😎🍺.](https://www.buymeacoffee.com/0dQ7tNG)

--- a/README.md
+++ b/README.md
@@ -267,7 +267,9 @@ Using this extension the swagger path settings must be in a file called: `ocelot
 WebHost.CreateDefaultBuilder(args)
   .ConfigureAppConfiguration((hostingContext, config) =>
   {
-     config.AddOcelotWithSwaggerSupport(fileOfSwaggerEndPoints: "ocelot.swagger")
+     config.AddOcelotWithSwaggerSupport((o) => {
+       o.FileOfSwaggerEndPoints = "ocelot.swagger";
+     })
   })
   .UseStartup<Startup>();
 ```
@@ -278,9 +280,11 @@ Optionally you can put the configuration files in a folder, and for that you hav
 WebHost.CreateDefaultBuilder(args)
   .ConfigureAppConfiguration((hostingContext, config) =>
   {
-    config.AddOcelotWithSwaggerSupport();
+    config.AddOcelotWithSwaggerSupport((o) => {
+      o.Folder = "Configuration";
+    });
   })
-  .UseStartup<Startup>(folder: "Configuration");
+  .UseStartup<Startup>();
 ```
 
 Optionally you can also add configuration files with the format `ocelot.exampleName.json` per environment, to use this functionality you must configure the extension as follows:
@@ -289,9 +293,25 @@ Optionally you can also add configuration files with the format `ocelot.exampleN
 WebHost.CreateDefaultBuilder(args)
   .ConfigureAppConfiguration((hostingContext, config) =>
   {
-    config.AddOcelotWithSwaggerSupport(environment: hostingContext.HostingEnvironment);
+    config.AddOcelotWithSwaggerSupport((o) => {
+      o.Folder = "Configuration";
+      o.Environment = hostingContext.HostingEnvironment;
+    });
   })
-  .UseStartup<Startup>(folder: "Configuration");
+  .UseStartup<Startup>();
+```
+
+To save the primary Ocelot config file under a name other than `ocelot.json then use the following:
+
+```CSharp
+WebHost.CreateDefaultBuilder(args)
+  .ConfigureAppConfiguration((hostingContext, config) =>
+  {
+    config.AddOcelotWithSwaggerSupport((o) => {
+      o.PrimaryOcelotConfigFile = "myOcelot.json";
+    });
+  })
+  .UseStartup<Startup>();
 ```
 
 ## Limitation

--- a/demo/ApiGateway/Program.cs
+++ b/demo/ApiGateway/Program.cs
@@ -23,7 +23,9 @@ namespace ApiGateway
                         .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json",
                             optional: true, reloadOnChange: true)
                         .AddJsonFile($"appsettings.local.json", optional: true, reloadOnChange: true)
-                        .AddOcelotWithSwaggerSupport(folder: "Configuration")
+                        .AddOcelotWithSwaggerSupport((o)=> {
+                            o.Folder = "Configuration";
+                        })
                         .AddEnvironmentVariables();
                 })
                 .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());

--- a/src/MMLib.SwaggerForOcelot/Configuration/OcelotWithSwaggerOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/OcelotWithSwaggerOptions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace MMLib.SwaggerForOcelot.Configuration
+{
+    /// <summary>
+    /// Ocelot with Swagger option.
+    /// </summary>
+    public class OcelotWithSwaggerOptions
+    {
+        /// <summary>
+        /// Folder of files of configuration of Ocelot.
+        /// </summary>
+        public string Folder { get; set; } = "/";
+
+        /// <summary>
+        /// Name of file of configuration SwaggerForOcelot without .json extension.
+        /// </summary>
+        public string FileOfSwaggerEndPoints { get; set; } = SwaggerForOcelotFileOptions.SwaggerEndPointsConfigFile;
+
+        /// <summary>
+        /// Gets or sets the name of the Ocelot primary configuration file.
+        /// </summary>
+        public string PrimaryOcelotConfigFileName { get; set; } = SwaggerForOcelotFileOptions.PrimaryOcelotConfigFile;
+
+        /// <summary>
+        /// Environment of net core app.
+        /// </summary>
+        public IHostEnvironment HostEnvironment  { get; set; }
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Kros.Extensions;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using MMLib.SwaggerForOcelot.Configuration;
@@ -20,27 +19,46 @@ namespace MMLib.SwaggerForOcelot.DependencyInjection
         private const string OcelotFilePattern = @"^ocelot\.(.*?)\.json$";
 
         /// <summary>
-        /// Extension for compatibility of functionality multifile of ocelot
+        /// Extension for compatibility of functionality multifile of ocelot.
         /// </summary>
-        /// <param name="builder">builder of net core for call this extension</param>
-        /// <param name="environment">environment of net core app</param>
-        /// <param name="folder">folder of files of configuration of ocelot</param>
-        /// <param name="fileOfSwaggerEndPoints">name of file of configuration SwaggerForOcelot without .json extension</param>
-        /// <returns>a Object IConfigurationBuilder</returns>
+        /// <param name="builder">Builder of net core for call this extension.</param>
+        /// <param name="environment">Environment of net core app.</param>
+        /// <param name="folder">Folder of files of configuration of ocelot.</param>
+        /// <param name="fileOfSwaggerEndPoints">Name of file of configuration SwaggerForOcelot without .json extension.</param>
         public static IConfigurationBuilder AddOcelotWithSwaggerSupport(
             this IConfigurationBuilder builder,
             IHostEnvironment environment = null,
             string folder = "/",
             string fileOfSwaggerEndPoints = SwaggerForOcelotFileOptions.SwaggerEndPointsConfigFile)
+            => AddOcelotWithSwaggerSupport(builder, (o) =>
+            {
+
+                o.Folder = folder;
+                o.FileOfSwaggerEndPoints = fileOfSwaggerEndPoints;
+                o.HostEnvironment = environment;
+            });
+
+        /// <summary>
+        /// Extension for compatibility of functionality multifile of ocelot.
+        /// </summary>
+        /// <param name="builder">Builder of net core for call this extension.</param>
+        /// <param name="action">Configuration action.</param>
+        public static IConfigurationBuilder AddOcelotWithSwaggerSupport(
+            this IConfigurationBuilder builder,
+            Action<OcelotWithSwaggerOptions> action = null)
         {
-            List<FileInfo> files = GetListOfOcelotFiles(folder, environment?.EnvironmentName);
+            var options = new OcelotWithSwaggerOptions();
+
+            action?.Invoke(options);
+
+            List<FileInfo> files = GetListOfOcelotFiles(options.Folder, options.HostEnvironment?.EnvironmentName);
             SwaggerFileConfiguration fileConfigurationMerged =
-                MergeFilesOfOcelotConfiguration(files, fileOfSwaggerEndPoints, environment?.EnvironmentName);
+                MergeFilesOfOcelotConfiguration(files, options.FileOfSwaggerEndPoints, options.HostEnvironment?.EnvironmentName);
             string jsonFileConfiguration = JsonConvert.SerializeObject(fileConfigurationMerged);
 
-            File.WriteAllText(SwaggerForOcelotFileOptions.PrimaryOcelotConfigFile, jsonFileConfiguration);
+            File.WriteAllText(options.PrimaryOcelotConfigFileName, jsonFileConfiguration);
 
-            builder.AddJsonFile(SwaggerForOcelotFileOptions.PrimaryOcelotConfigFile, optional: false, reloadOnChange: false);
+            builder.AddJsonFile(options.PrimaryOcelotConfigFileName, optional: false, reloadOnChange: false);
 
             return builder;
         }
@@ -48,10 +66,10 @@ namespace MMLib.SwaggerForOcelot.DependencyInjection
         #region Private Methods
 
         /// <summary>
-        /// Get files of ocelot Configuration with a filter of envirotment
+        /// Get files of ocelot Configuration with a filter of envirotment.
         /// </summary>
         /// <param name="folder"></param>
-        /// <returns>a var of type List<FileInfo> with the list of files of configuration of ocelot</returns>
+        /// <returns>A var of type List<FileInfo> with the list of files of configuration of ocelot.</returns>
         private static List<FileInfo> GetListOfOcelotFiles(string folder, string nameEnvirotment)
         {
             var reg = new Regex(OcelotFilePattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -68,13 +86,6 @@ namespace MMLib.SwaggerForOcelot.DependencyInjection
             return ocelotFiles.ToList();
         }
 
-        /// <summary>
-        /// Merge a list of files of configuration of Ocelot with options SwaggerEnpoints
-        /// </summary>
-        /// <param name="files"></param>
-        /// <param name="fileOfSwaggerEndPoints"></param>
-        /// <param name="environmentName"></param>
-        /// <returns>a object SwaggerFileConfiguration with the configuration of file</returns>
         private static SwaggerFileConfiguration MergeFilesOfOcelotConfiguration(
             List<FileInfo> files,
             string fileOfSwaggerEndPoints,

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -30,8 +30,7 @@ namespace MMLib.SwaggerForOcelot.DependencyInjection
             IHostEnvironment environment = null,
             string folder = "/",
             string fileOfSwaggerEndPoints = SwaggerForOcelotFileOptions.SwaggerEndPointsConfigFile)
-            => AddOcelotWithSwaggerSupport(builder, (o) =>
-            {
+            => AddOcelotWithSwaggerSupport(builder, (o) => {
 
                 o.Folder = folder;
                 o.FileOfSwaggerEndPoints = fileOfSwaggerEndPoints;

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -30,8 +30,8 @@ namespace MMLib.SwaggerForOcelot.DependencyInjection
             IHostEnvironment environment = null,
             string folder = "/",
             string fileOfSwaggerEndPoints = SwaggerForOcelotFileOptions.SwaggerEndPointsConfigFile)
-            => AddOcelotWithSwaggerSupport(builder, (o) => {
-
+            => AddOcelotWithSwaggerSupport(builder, (o) =>
+            {
                 o.Folder = folder;
                 o.FileOfSwaggerEndPoints = fileOfSwaggerEndPoints;
                 o.HostEnvironment = environment;


### PR DESCRIPTION
Add fileName as a parameter to `.AddOcelotWithSwaggerSupport()`. Inspired by @pateljeel #125.

Now you can call
```CSharp
config..AddOcelotWithSwaggerSupport((o)=> {
   o.Folder = "Configuration";
   o.PrimaryOcelotConfigFileName = "myOcelot.json";
})
```