### PR TITLE
Upgrade to Ocelot v17 and .NET 5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET Core if needed
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: 5.0.101
     - name: Build
       run: dotnet build ./MMLib.SwaggerForOcelot.sln --configuration Release
     - name: Test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup .NET Core if needed
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: 5.0.101
     - name: Build
       run: dotnet build ./MMLib.SwaggerForOcelot.sln --configuration Release
     - name: Test

--- a/demo/ApiGateway/ApiGateway.csproj
+++ b/demo/ApiGateway/ApiGateway.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
     <PackageReference Include="MMLib.Ocelot.Provider.AppConfiguration" Version="1.1.0" />
-    <PackageReference Include="Ocelot" Version="16.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+    <PackageReference Include="Ocelot" Version="17.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/ApiGateway/ApiGateway.csproj
+++ b/demo/ApiGateway/ApiGateway.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
-    <PackageReference Include="MMLib.Ocelot.Provider.AppConfiguration" Version="1.1.0" />
+    <PackageReference Include="MMLib.Ocelot.Provider.AppConfiguration" Version="2.0.0" />
     <PackageReference Include="Ocelot" Version="17.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>

--- a/demo/ApiGatewayWithEndpointInterceptor/ApiGatewayWithEndpointInterceptor.csproj
+++ b/demo/ApiGatewayWithEndpointInterceptor/ApiGatewayWithEndpointInterceptor.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>ApiGatewayWithEndpointSecurity</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Ocelot" Version="16.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+    <PackageReference Include="Ocelot" Version="17.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
+++ b/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Ocelot" Version="16.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+    <PackageReference Include="Ocelot" Version="17.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/ContactService/ContactService.csproj
+++ b/demo/ContactService/ContactService.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 
 </Project>

--- a/demo/ContactService/Startup.cs
+++ b/demo/ContactService/Startup.cs
@@ -40,6 +40,8 @@ namespace ContactService
             }
 
             app.UseRouting();
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+
             app.UseSwagger()
                 .UseSwaggerUI(c =>
                 {

--- a/demo/OrderService/OrderService.csproj
+++ b/demo/OrderService/OrderService.csproj
@@ -1,18 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
  <PropertyGroup>
-  <TargetFramework>netcoreapp3.0</TargetFramework>
+  <TargetFramework>net5.0</TargetFramework>
   <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   <RootNamespace>OrderService</RootNamespace>
   <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildThisFileName).xml</DocumentationFile>
  </PropertyGroup>
 
  <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.App" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.0.0" />
-  <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-  <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+  <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
  </ItemGroup>
 
 

--- a/demo/OrderService/Startup.cs
+++ b/demo/OrderService/Startup.cs
@@ -78,6 +78,7 @@ namespace OrderService
         public void Configure(IApplicationBuilder app, IApiVersionDescriptionProvider provider)
         {
             app.UseRouting();
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
             app.UseSwagger();
             _ = app.UseSwaggerUI(
                 options =>

--- a/demo/PetstoreService/PetstoreService.csproj
+++ b/demo/PetstoreService/PetstoreService.csproj
@@ -1,13 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="wwwroot\swagger.json" />

--- a/demo/ProjectService/ProjectService.csproj
+++ b/demo/ProjectService/ProjectService.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="MMLib.RapidPrototyping" Version="1.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 
 </Project>

--- a/demo/ProjectService/Startup.cs
+++ b/demo/ProjectService/Startup.cs
@@ -41,6 +41,7 @@ namespace ProjectService
             }
 
             app.UseRouting();
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
 
             app.UseSwagger()
                 .UseSwaggerUI(c =>

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddSwaggerGen(c =>
             {
-                swaggerSetup(c);
+                swaggerSetup?.Invoke(c);
 
                 AddAggregatesDocs(c, options);
                 AddGatewayItSelfDocs(c, options);

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.2.0</Version>
+    <TargetFramework>net5.0</TargetFramework>
+    <Version>4.0.0</Version>
     <Authors>Milan Martiniak</Authors>
     <Company>MMLib</Company>
     <Description>Swagger generator for Ocelot downstream services.</Description>
@@ -28,8 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="Kros.Utils" Version="1.10.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.1" />
-    <PackageReference Include="Ocelot" Version="16.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Ocelot" Version="17.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
   </ItemGroup>

--- a/src/MMLib.SwaggerForOcelot/Repositories/DownstreamSwaggerDocsRepository.cs
+++ b/src/MMLib.SwaggerForOcelot/Repositories/DownstreamSwaggerDocsRepository.cs
@@ -68,8 +68,13 @@ namespace MMLib.SwaggerForOcelot.Repositories
             string downstreamHttpVersion = route?.DownstreamHttpVersion;
             if (!downstreamHttpVersion.IsNullOrEmpty())
             {
-                int[] version = downstreamHttpVersion.Split('.').Select(int.Parse).ToArray();
+                int[] version = downstreamHttpVersion!.Split('.').Select(int.Parse).ToArray();
                 httpClient.DefaultRequestVersion = new Version(version[0], version[1]);
+                // HTTP/2 over insecure http requires non-default version policy.
+                if (route?.DownstreamScheme == "http" && version[0] == 2)
+                {
+                    httpClient.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                }
             }
         }
 

--- a/src/MMLib.SwaggerForOcelot/RouteOptionsExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/RouteOptionsExtensions.cs
@@ -10,7 +10,7 @@ namespace MMLib.SwaggerForOcelot
     internal static class RouteOptionsExtensions
     {
         /// <summary>
-        /// Goups the re routes by paths.
+        /// Groups the re routes by paths.
         /// </summary>
         /// <param name="routeOptions">The re route options.</param>
         public static IEnumerable<RouteOptions> GroupByPaths(this IEnumerable<RouteOptions> routeOptions)
@@ -25,7 +25,8 @@ namespace MMLib.SwaggerForOcelot
                     p.Key.VirtualDirectory,
                     p.Where(r => r.UpstreamHttpMethod != null).SelectMany(r => r.UpstreamHttpMethod))
                 {
-                    DownstreamHttpVersion = route.DownstreamHttpVersion
+                    DownstreamHttpVersion = route.DownstreamHttpVersion,
+                    DownstreamScheme = route.DownstreamScheme
                 };
             });
 
@@ -62,7 +63,8 @@ namespace MMLib.SwaggerForOcelot
                         routeOption.UpstreamPathTemplate.Replace(endPoint.VersionPlaceholder,
                             c.Version),
                     VirtualDirectory = routeOption.VirtualDirectory,
-                    DownstreamHttpVersion = routeOption.DownstreamHttpVersion
+                    DownstreamHttpVersion = routeOption.DownstreamHttpVersion,
+                    DownstreamScheme = routeOption.DownstreamScheme
                 });
                 routeOptions.AddRange(versionMappedRouteOptions);
             }

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
With Ocelot v17 released using .NET 5, this library needs to upgrade as well. :)

I specifically needed to upgrade in order to properly set up the HttpClient when making insecure HTTP/2 downstream requests after upgrading my downstream services to .NET 5.  There were breaking changes in how to set that up.


