### PR TITLE
Fix using current folder for merging conf files

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Configuration/OcelotWithSwaggerOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/OcelotWithSwaggerOptions.cs
@@ -10,7 +10,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// <summary>
         /// Folder of files of configuration of Ocelot.
         /// </summary>
-        public string Folder { get; set; } = "/";
+        public string Folder { get; set; } = "./";
 
         /// <summary>
         /// Name of file of configuration SwaggerForOcelot without .json extension.


### PR DESCRIPTION
* Fix using current folder for merge configuration files by default.

Symbol "/" points to the root of the file-system. Symbol "./" points to the working folder of the application. It leads to an unexpected behavior. Developer may expect that configuration files should be placed in the working dir, while application try to search in the root by default.