### PR TITLE
Add OpenAPI servers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,31 @@ app.UseSwaggerForOcelotUI(opt => {
 
    > `http://ocelotserviceurl/swagger`
 
+## Open API Servers
+
+If you have multiple servers defined in the downstream service Open API documentation, or you use server templating and you want to use it on the gateway side as well, then you must explicitly enable it on the Swagger endpoint definition by setting property `TakeServersFromDownstreamService` to `true`.
+
+```json
+"SwaggerEndPoints": [
+    {
+      "Key": "users",
+      "TakeServersFromDownstreamService": true,
+      "Config": [
+        {
+          "Name": "Users API",
+          "Version": "v1",
+          "Service": {
+            "Name": "users",
+            "Path": "/swagger/v1/swagger.json"
+          }
+        }
+      ]
+    }
+]
+```
+
+> ⚠ If you set `TakeServersFromDownstreamService` to `true`, then the server path is not used to transform the paths of individual endpoints.
+
 ## Virtual directory
 
 If you have a `downstream service` hosted in the virtual directory, you probably have a `DownstreamPathTemplate` starting with the name of this virtual directory `/virtualdirectory/api/{everything}`. In order to properly replace the paths, it is necessary to set the property route `"Virtualdirectory":"/virtualdirectory"`.

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
@@ -46,6 +46,14 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// </value>
         public bool TransformByOcelotConfig { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether can take open api servers list from downstream service.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [take servers from downstream service]; otherwise, <c>false</c>.
+        /// </value>
+        public bool TakeServersFromDownstreamService { get; set; } = false;
+
         internal bool IsGatewayItSelf => Config != null && Config.Any(c => c.IsGatewayItSelf);
     }
 }

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>4.0.2</Version>
+    <Version>4.1.0</Version>
     <Authors>Milan Martiniak</Authors>
     <Company>MMLib</Company>
     <Description>Swagger generator for Ocelot downstream services.</Description>

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -78,7 +78,11 @@ namespace MMLib.SwaggerForOcelot.Middleware
 
             if (endPoint.TransformByOcelotConfig)
             {
-                content = _transformer.Transform(content, routeOptions, GetServerName(context, endPoint));
+                content = _transformer.Transform(
+                    content,
+                    routeOptions,
+                    GetServerName(context, endPoint),
+                    endPoint.TakeServersFromDownstreamService);
             }
             content = await ReconfigureUpstreamSwagger(context, content);
 

--- a/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
@@ -14,9 +14,15 @@ namespace MMLib.SwaggerForOcelot.Transformation
         /// <param name="swaggerJson">The swagger json.</param>
         /// <param name="routes">The re routes.</param>
         /// <param name="serverOverride">The host override to add to swagger json.</param>
+        /// <param name="transformByOcelotConfig">
+        /// Indicating whether can take open api servers list from downstream service.
+        /// </param>
         /// <returns>
         /// Transformed swagger json.
         /// </returns>
-        string Transform(string swaggerJson, IEnumerable<RouteOptions> routes, string serverOverride);
+        string Transform(string swaggerJson,
+            IEnumerable<RouteOptions> routes,
+            string serverOverride,
+            bool takeServersFromDownstreamService);
     }
 }

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -10,6 +10,7 @@
     <None Remove="Tests\Issue_135.json" />
     <None Remove="Tests\Issue_149.json" />
     <None Remove="Tests\Issue_65.json" />
+    <None Remove="Tests\OpenApiWithListOfServers.json" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\AggregatesOpenApiResource.json" />
@@ -28,6 +29,8 @@
     <EmbeddedResource Include="Tests\Issue_65.json" />
 
     <EmbeddedResource Include="Tests\Issue_128.json" />
+
+    <EmbeddedResource Include="Tests\OpenApiWithListOfServers.json" />
     <EmbeddedResource Include="Tests\SwaggerWithBasePath.json" />
     <EmbeddedResource Include="Tests\OcelotRouteOnlyOneController.json" />
     <EmbeddedResource Include="Tests\BasicConfigurationWithVirtualDirectory.json" />

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -74,12 +74,14 @@ namespace MMLib.SwaggerForOcelot.Tests
                 .Setup(x => x.Transform(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RouteOptions>>(),
-                    It.IsAny<string>()))
+                    It.IsAny<string>(),
+                    It.IsAny<bool>()))
                 .Returns((
                     string swaggerJson,
                     IEnumerable<RouteOptions> routeOptions,
-                    string serverOverride) => new SwaggerJsonTransformer()
-                    .Transform(swaggerJson,routeOptions, serverOverride));
+                    string serverOverride,
+                    bool servers) => new SwaggerJsonTransformer()
+                    .Transform(swaggerJson,routeOptions, serverOverride, servers));
             var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
                 next.Invoke,
                 swaggerForOcelotOptions,
@@ -103,7 +105,7 @@ namespace MMLib.SwaggerForOcelot.Tests
             swaggerJsonTransformerMock.Verify(x => x.Transform(
                 It.IsAny<string>(),
                 It.IsAny<IEnumerable<RouteOptions>>(),
-                It.IsAny<string>()), Times.Once);
+                It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
         }
 
         [Fact]
@@ -186,12 +188,14 @@ namespace MMLib.SwaggerForOcelot.Tests
                 .Setup(x => x.Transform(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RouteOptions>>(),
-                    It.IsAny<string>()))
+                    It.IsAny<string>(),
+                    It.IsAny<bool>()))
                 .Returns((
                     string swaggerJson,
                     IEnumerable<RouteOptions> routeOptions,
-                    string serverOverride) => new SwaggerJsonTransformer()
-                    .Transform(swaggerJson, routeOptions, serverOverride));
+                    string serverOverride,
+                    bool servers) => new SwaggerJsonTransformer()
+                    .Transform(swaggerJson, routeOptions, serverOverride, servers));
             var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
                 next.Invoke,
                 swaggerForOcelotOptions,
@@ -383,7 +387,10 @@ namespace MMLib.SwaggerForOcelot.Tests
                 _transformedJson = transformedJson;
             }
 
-            public string Transform(string swaggerJson, IEnumerable<RouteOptions> routes, string serverOverride)
+            public string Transform(string swaggerJson,
+                IEnumerable<RouteOptions> routes,
+                string serverOverride,
+                bool transformByOcelotConfig)
             {
                 return _transformedJson;
             }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
@@ -8,7 +8,7 @@ using Xunit.Sdk;
 namespace MMLib.SwaggerForOcelot.Tests
 {
     /// <summary>
-    /// Generic tests for transformation downstream swagger to upstream format. 
+    /// Generic tests for transformation downstream swagger to upstream format.
     /// Source test cases are located as resources in '/tests' folder and providing by <see cref="TestCasesProvider" />.
     /// </summary>
     public class SwaggerForOcelotShould
@@ -22,7 +22,8 @@ namespace MMLib.SwaggerForOcelot.Tests
             string transformed = transformer.Transform(
                 testData.DownstreamSwagger.ToString(),
                 testData.Routes,
-                testData.HostOverride);
+                testData.HostOverride,
+                testData.TakeServersFromDownstreamService);
 
             AreEqual(transformed, testData.ExpectedTransformedSwagger, testData.FileName);
         }

--- a/tests/MMLib.SwaggerForOcelot.Tests/TestCase.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/TestCase.cs
@@ -40,6 +40,14 @@ namespace MMLib.SwaggerForOcelot.Tests
         public JObject ExpectedTransformedSwagger { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether can take open api servers list from downstream service.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [take servers from downstream service]; otherwise, <c>false</c>.
+        /// </value>
+        public bool TakeServersFromDownstreamService { get; set; } = false;
+
+        /// <summary>
         /// Test name.
         /// </summary>
         public override string ToString() => $"{Name} ({FileName})";

--- a/tests/MMLib.SwaggerForOcelot.Tests/Tests/OpenApiWithListOfServers.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Tests/OpenApiWithListOfServers.json
@@ -1,0 +1,405 @@
+{
+  "name": "Open Api version with list of servers.",
+  "description": "Take servers from downstream dervice.",
+  "hostOverride": "http://override.host.it",
+  "takeServersFromDownstreamService": true,
+  "routes": [
+    {
+      "DownstreamPathTemplate": "/api/{everything}",
+      "UpstreamPathTemplate": "/api/projects/{everything}",
+      "SwaggerKey": "projects"
+    }
+  ],
+  "downstreamSwagger": {
+    "openapi": "3.0",
+    "info": {
+      "version": "v1",
+      "title": "Projects API"
+    },
+    "servers": [
+      {
+        "url": "https://gateway.company.{tld}/{tenantHost}",
+        "description": "My Application via Gateway",
+        "variables": {
+          "tld": {
+            "default": "com",
+            "description": "The environment.",
+            "enum": [
+              "com",
+              "net",
+              "co.uk"
+            ]
+          },
+          "tenantHost": {
+            "default": "myTenant",
+            "description": "The hostname of the tenant."
+          }
+        }
+      },
+      {
+        "url": "/"
+      }
+    ],
+    "paths": {
+      "/api/Projects": {
+        "get": {
+          "tags": [
+            "Projects"
+          ],
+          "operationId": "Get",
+          "consumes": [],
+          "produces": [
+            "text/plain",
+            "application/json",
+            "text/json"
+          ],
+          "parameters": [],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "schema": {
+                "uniqueItems": false,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/Projects/{id}": {
+        "get": {
+          "tags": [
+            "Projects"
+          ],
+          "operationId": "Get",
+          "consumes": [],
+          "produces": [
+            "text/plain",
+            "application/json",
+            "text/json"
+          ],
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "type": "integer",
+              "format": "int32"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "schema": {
+                "$ref": "#/components/schemas/Project"
+              }
+            },
+            "404": {
+              "description": "Not Found"
+            }
+          }
+        }
+      },
+      "/api/Projects/projectCreate": {
+        "post": {
+          "tags": [
+            "Projects"
+          ],
+          "operationId": "CreateProject",
+          "consumes": [
+            "application/json-patch+json",
+            "application/json",
+            "text/json",
+            "application/*+json"
+          ],
+          "produces": [],
+          "parameters": [
+            {
+              "name": "projectViewModel",
+              "in": "body",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/ProjectViewModel"
+              }
+            }
+          ],
+          "responses": {
+            "201": {
+              "description": "Success"
+            },
+            "400": {
+              "description": "Bad Request"
+            }
+          }
+        }
+      },
+      "/api/Values": {
+        "get": {
+          "tags": [
+            "Values"
+          ],
+          "operationId": "Get",
+          "consumes": [],
+          "produces": [
+            "text/plain",
+            "application/json",
+            "text/json"
+          ],
+          "parameters": [],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "schema": {
+                "uniqueItems": false,
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "Project": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            }
+          }
+        },
+        "ProjectViewModel": {
+          "required": [
+            "name",
+            "owner"
+          ],
+          "type": "object",
+          "properties": {
+            "name": {
+              "maxLength": 50,
+              "type": "string"
+            },
+            "description": {
+              "maxLength": 255,
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedTransformedSwagger": {
+    "openapi": "3.0",
+    "info": {
+      "version": "v1",
+      "title": "Projects API"
+    },
+    "servers": [
+      {
+        "url": "https://gateway.company.{tld}/{tenantHost}",
+        "description": "My Application via Gateway",
+        "variables": {
+          "tld": {
+            "default": "com",
+            "description": "The environment.",
+            "enum": [
+              "com",
+              "net",
+              "co.uk"
+            ]
+          },
+          "tenantHost": {
+            "default": "myTenant",
+            "description": "The hostname of the tenant."
+          }
+        }
+      },
+      {
+        "url": "/"
+      }
+    ],
+    "paths": {
+      "/api/projects/Projects": {
+        "get": {
+          "tags": [
+            "Projects"
+          ],
+          "operationId": "Get",
+          "consumes": [],
+          "produces": [
+            "text/plain",
+            "application/json",
+            "text/json"
+          ],
+          "parameters": [],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "schema": {
+                "uniqueItems": false,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/projects/Projects/{id}": {
+        "get": {
+          "tags": [
+            "Projects"
+          ],
+          "operationId": "Get",
+          "consumes": [],
+          "produces": [
+            "text/plain",
+            "application/json",
+            "text/json"
+          ],
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "type": "integer",
+              "format": "int32"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "schema": {
+                "$ref": "#/components/schemas/Project"
+              }
+            },
+            "404": {
+              "description": "Not Found"
+            }
+          }
+        }
+      },
+      "/api/projects/Projects/projectCreate": {
+        "post": {
+          "tags": [
+            "Projects"
+          ],
+          "operationId": "CreateProject",
+          "consumes": [
+            "application/json-patch+json",
+            "application/json",
+            "text/json",
+            "application/*+json"
+          ],
+          "produces": [],
+          "parameters": [
+            {
+              "name": "projectViewModel",
+              "in": "body",
+              "required": false,
+              "schema": {
+                "$ref": "#/components/schemas/ProjectViewModel"
+              }
+            }
+          ],
+          "responses": {
+            "201": {
+              "description": "Success"
+            },
+            "400": {
+              "description": "Bad Request"
+            }
+          }
+        }
+      },
+      "/api/projects/Values": {
+        "get": {
+          "tags": [
+            "Values"
+          ],
+          "operationId": "Get",
+          "consumes": [],
+          "produces": [
+            "text/plain",
+            "application/json",
+            "text/json"
+          ],
+          "parameters": [],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "schema": {
+                "uniqueItems": false,
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "Project": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            }
+          }
+        },
+        "ProjectViewModel": {
+          "required": [
+            "name",
+            "owner"
+          ],
+          "type": "object",
+          "properties": {
+            "name": {
+              "maxLength": 50,
+              "type": "string"
+            },
+            "description": {
+              "maxLength": 255,
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Support for OpenAPI Servers.

---

If you have multiple servers defined in the downstream service Open API documentation, or you use server templating and you want to use it on the gateway side as well, then you must explicitly enable it on the Swagger endpoint definition by setting property `TakeServersFromDownstreamService` to `true`.

```json
"SwaggerEndPoints": [
    {
      "Key": "users",
      "TakeServersFromDownstreamService": true,
      "Config": [
        {
          "Name": "Users API",
          "Version": "v1",
          "Service": {
            "Name": "users",
            "Path": "/swagger/v1/swagger.json"
          }
        }
      ]
    }
]
```

> ⚠ If you set `TakeServersFromDownstreamService` to `true`, then the server path is not used to transform the paths of individual endpoints.