### PR TITLE
Fix of documentation generation for aggregation

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Aggregates/RouteDocs.cs
+++ b/src/MMLib.SwaggerForOcelot/Aggregates/RouteDocs.cs
@@ -123,7 +123,7 @@ namespace MMLib.SwaggerForOcelot.Aggregates
         /// </summary>
         public OpenApiResponse GetResponse()
         {
-            var response = Docs[PathKey].SelectToken("responses.200")?.ToObject(typeof(Response), _serializer) as Response;
+            var response = Docs[PathKey]?.SelectToken("responses.200")?.ToObject(typeof(Response), _serializer) as Response;
 
             return new OpenApiResponse()
             {
@@ -134,22 +134,28 @@ namespace MMLib.SwaggerForOcelot.Aggregates
 
         private Dictionary<string, OpenApiMediaType> CreateContent(Response response)
         {
-            OpenApiMediaTypeEx content = response?.Content[MediaTypeNames.Application.Json];
             var ret = new Dictionary<string, OpenApiMediaType>();
-
-            if (content != null)
+            if (response?.Content is null)
             {
-                if (!content.SchemaExt.IsReference)
-                {
-                    content.SetSchema();
-                }
-                else
-                {
-                    FindSchema(content);
-                }
-
-                ret.Add(MediaTypeNames.Application.Json, content);
+                return ret;
             }
+
+            OpenApiMediaTypeEx content = response.Content[MediaTypeNames.Application.Json];
+            if (content == null)
+            {
+                return ret;
+            }
+
+            if (!content.SchemaExt.IsReference)
+            {
+                content.SetSchema();
+            }
+            else
+            {
+                FindSchema(content);
+            }
+
+            ret.Add(MediaTypeNames.Application.Json, content);
 
             return ret;
         }

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>4.4.1</Version>
+    <Version>4.4.2</Version>
     <Authors>Milan Martiniak</Authors>
     <Company>MMLib</Company>
     <Description>Swagger generator for Ocelot downstream services.</Description>

--- a/tests/MMLib.SwaggerForOcelot.Tests/Aggregates/RoutesDocumentationProviderShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Aggregates/RoutesDocumentationProviderShould.cs
@@ -20,6 +20,7 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
         [InlineData("serviceWithMoreSimpleParameter1", "serviceWithMoreSimpleParameter2", "/{id}/{message}")]
         [InlineData("serviceWithMoreSimpleParameter1", "serviceWithMoreSimpleParameterAnotherNames", "/{id}/{message}", "{id}-{idcko};{message}-{sprava}")]
         [InlineData("moreMethod1", "moreMethod2")]
+        [InlineData("withoutcontent1", "withoutcontent2")]
         public async Task GetDocs(string firstService, string secondService, string parameters = null, string paramsMap = null)
         {
             RoutesDocumentationProvider provider = await CreateProviderAsync();

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/AggregatesOpenApiResource.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/AggregatesOpenApiResource.json
@@ -125,6 +125,32 @@
         }
       }
     },
+    "/api/withoutcontent1/endpoint1": {
+      "get": {
+        "tags": [
+          "withoutcontent1"
+        ],
+        "summary": "withoutcontent1 - endpoint 1",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/withoutcontent2/endpoint1": {
+      "get": {
+        "tags": [
+          "withoutcontent2"
+        ],
+        "summary": "withoutcontent2 - endpoint 1",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/api/serviceWithSimpleParameter1/endpoint1/{id}": {
       "get": {
         "tags": [


### PR DESCRIPTION
Fix issue #183

If the downstream route response documentation did not contain content, it was not possible to generate documentation for the given aggregate.

