### PR TITLE
Do not remove un used components

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,25 @@ Note, this does not affect nor checks the swagger document's `securityDefinition
 
 - Now, this library support only `{everything}` as a wildcard in routing definition. #68
 - This package unfortunately does not support parameter translating between upstream and downstream path template. #59
+- If your downstream documentation is too large (usually more than 10 MB), the response may be too slow. You can turn off the removal of an unused schema component from downstream documentation by using `RemoveUnusedComponentsFromScheme: false`.
+```csharp
+ "SwaggerEndPoints": [
+    {
+      "Key": "projects",
+      "RemoveUnusedComponentsFromScheme": false,
+      "Config": [
+        {
+          "Name": "Projects API",
+          "Version": "v1",
+          "Service": {
+            "Name": "projects",
+            "Path": "/swagger/v1/swagger.json"
+          }
+        }
+      ]
+    }
+  ]
+```
 
 ## Version 2.0.0
 

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
@@ -47,6 +47,11 @@ namespace MMLib.SwaggerForOcelot.Configuration
         public bool TransformByOcelotConfig { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to remove unused components from the documentation.
+        /// </summary>
+        public bool RemoveUnusedComponentsFromScheme { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets a value indicating whether can take open api servers list from downstream service.
         /// </summary>
         /// <value>

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>4.7.0</Version>
+    <Version>4.8.0</Version>
     <Authors>Milan Martiniak</Authors>
     <Company>MMLib</Company>
     <Description>Swagger generator for Ocelot downstream services.</Description>

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -99,7 +99,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
                     content,
                     routeOptions,
                     GetServerName(context, endPoint),
-                    endPoint.TakeServersFromDownstreamService);
+                    endPoint);
             }
             content = await ReconfigureUpstreamSwagger(context, content);
 

--- a/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
@@ -14,15 +14,13 @@ namespace MMLib.SwaggerForOcelot.Transformation
         /// <param name="swaggerJson">The swagger json.</param>
         /// <param name="routes">The re routes.</param>
         /// <param name="serverOverride">The host override to add to swagger json.</param>
-        /// <param name="transformByOcelotConfig">
-        /// Indicating whether can take open api servers list from downstream service.
-        /// </param>
+        /// <param name="endPointOptions">Endpoint options.</param>
         /// <returns>
         /// Transformed swagger json.
         /// </returns>
         string Transform(string swaggerJson,
             IEnumerable<RouteOptions> routes,
             string serverOverride,
-            bool takeServersFromDownstreamService);
+            SwaggerEndPointOptions endPointOptions);
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -22,11 +22,10 @@ namespace MMLib.SwaggerForOcelot.Transformation
         }
 
         /// <inheritdoc/>
-        public string Transform(
-            string swaggerJson,
+        public string Transform(string swaggerJson,
             IEnumerable<RouteOptions> routes,
             string serverOverride,
-            bool takeServersFromDownstreamService)
+            SwaggerEndPointOptions endPointOptions)
         {
             var swagger = JObject.Parse(swaggerJson);
 
@@ -37,7 +36,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
 
             if (swagger.ContainsKey("openapi"))
             {
-                return TransformOpenApi(swagger, routes, serverOverride, takeServersFromDownstreamService);
+                return TransformOpenApi(swagger, routes, serverOverride, endPointOptions);
             }
 
             throw new InvalidOperationException("Unknown swagger/openapi version");
@@ -90,11 +89,11 @@ namespace MMLib.SwaggerForOcelot.Transformation
             JObject openApi,
             IEnumerable<RouteOptions> routes,
             string serverOverride,
-            bool takeServersFromDownstreamService)
+            SwaggerEndPointOptions endPointOptions)
         {
             // NOTE: Only supporting one server for now.
             string downstreamBasePath = "";
-            if (openApi.ContainsKey(OpenApiProperties.Servers) && !takeServersFromDownstreamService)
+            if (openApi.ContainsKey(OpenApiProperties.Servers) && !endPointOptions.TakeServersFromDownstreamService)
             {
                 string firstServerUrl = openApi.GetValue(OpenApiProperties.Servers).First.Value<string>(OpenApiProperties.Url);
                 var downstreamUrl = new Uri(firstServerUrl, UriKind.RelativeOrAbsolute);
@@ -131,7 +130,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
                 }
             }
 
-            TransformServerPaths(openApi, serverOverride, takeServersFromDownstreamService);
+            TransformServerPaths(openApi, serverOverride, endPointOptions.TakeServersFromDownstreamService);
 
             return openApi.ToString(Formatting.Indented);
         }

--- a/tests/MMLib.SwaggerForOcelot.BenchmarkTests/SwaggerJsonTransfromerBenchmark.cs
+++ b/tests/MMLib.SwaggerForOcelot.BenchmarkTests/SwaggerJsonTransfromerBenchmark.cs
@@ -46,7 +46,7 @@ public class SwaggerJsonTransfromerBenchmark
     [Benchmark]
     public void Transform()
     {
-       _transformer.Transform(_swagger, _routeOptions,  string.Empty, false);
+       _transformer.Transform(_swagger, _routeOptions,  string.Empty, new SwaggerEndPointOptions());
     }
 
     private static string ReadFile(string testFilePath)

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -25,6 +25,8 @@
 
     <EmbeddedResource Include="Tests\BasicSecurityDefinition.json" />
 
+    <EmbeddedResource Include="Tests\DoNotRemoveUnusedComponents.json" />
+
     <EmbeddedResource Include="Tests\Issue_186.json" />
 
     <EmbeddedResource Include="Tests\Issue_149.json" />
@@ -34,6 +36,8 @@
     <EmbeddedResource Include="Tests\Issue_65.json" />
 
     <EmbeddedResource Include="Tests\Issue_128.json" />
+
+    <EmbeddedResource Include="Tests\OpenApiDoNotRemoveUnusedComponents.json" />
 
     <EmbeddedResource Include="Tests\OpenApiWithListOfServers.json" />
     <EmbeddedResource Include="Tests\SwaggerWithBasePath.json" />

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -43,19 +43,19 @@ namespace MMLib.SwaggerForOcelot.Tests
             TestSwaggerEndpointOptions swaggerEndpointOptions = CreateSwaggerEndpointOptions(key,version);
             var routeOptions = new TestRouteOptions(new List<RouteOptions>
             {
-                new RouteOptions
+                new()
                 {
                     SwaggerKey = "projects",
                     UpstreamPathTemplate ="/api/{version}/projects/Values/{everything}",
                     DownstreamPathTemplate ="/api/{version}/Values/{everything}",
                 },
-                new RouteOptions
+                new()
                 {
                     SwaggerKey = "projects",
                     UpstreamPathTemplate = "/api/projects/Projects",
                     DownstreamPathTemplate = "/api/Projects",
                 },
-                new RouteOptions
+                new()
                 {
                     SwaggerKey = "projects",
                     UpstreamPathTemplate = "/api/projects/Projects/{everything}",
@@ -77,13 +77,13 @@ namespace MMLib.SwaggerForOcelot.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RouteOptions>>(),
                     It.IsAny<string>(),
-                    It.IsAny<bool>()))
+                    It.IsAny<SwaggerEndPointOptions>()))
                 .Returns((
                     string swaggerJson,
                     IEnumerable<RouteOptions> routeOptions,
                     string serverOverride,
-                    bool servers) => new SwaggerJsonTransformer(OcelotSwaggerGenOptions.Default)
-                    .Transform(swaggerJson,routeOptions, serverOverride, servers));
+                    SwaggerEndPointOptions options) => new SwaggerJsonTransformer(OcelotSwaggerGenOptions.Default)
+                    .Transform(swaggerJson,routeOptions, serverOverride, options));
             var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
                 next.Invoke,
                 swaggerForOcelotOptions,
@@ -108,7 +108,8 @@ namespace MMLib.SwaggerForOcelot.Tests
             swaggerJsonTransformerMock.Verify(x => x.Transform(
                 It.IsAny<string>(),
                 It.IsAny<IEnumerable<RouteOptions>>(),
-                It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
+                It.IsAny<string>(),
+                It.IsAny<SwaggerEndPointOptions>()), Times.Once);
         }
 
         [Fact]
@@ -173,7 +174,7 @@ namespace MMLib.SwaggerForOcelot.Tests
             TestSwaggerEndpointOptions swaggerEndpointOptions = CreateSwaggerEndpointOptions(key,version);
             var routeOptions = new TestRouteOptions(new List<RouteOptions>
             {
-                new RouteOptions
+                new()
                 {
                     SwaggerKey = "projects",
                     UpstreamPathTemplate = "/api/projects/Projects",
@@ -193,13 +194,13 @@ namespace MMLib.SwaggerForOcelot.Tests
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RouteOptions>>(),
                     It.IsAny<string>(),
-                    It.IsAny<bool>()))
+                    It.IsAny<SwaggerEndPointOptions>()))
                 .Returns((
                     string swaggerJson,
                     IEnumerable<RouteOptions> routeOptions,
                     string serverOverride,
-                    bool servers) => new SwaggerJsonTransformer(OcelotSwaggerGenOptions.Default)
-                    .Transform(swaggerJson, routeOptions, serverOverride, servers));
+                    SwaggerEndPointOptions options) => new SwaggerJsonTransformer(OcelotSwaggerGenOptions.Default)
+                    .Transform(swaggerJson, routeOptions, serverOverride, options));
             var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
                 next.Invoke,
                 swaggerForOcelotOptions,
@@ -395,7 +396,7 @@ namespace MMLib.SwaggerForOcelot.Tests
             public string Transform(string swaggerJson,
                 IEnumerable<RouteOptions> routes,
                 string serverOverride,
-                bool transformByOcelotConfig)
+                SwaggerEndPointOptions endPointOptions)
             {
                 return _transformedJson;
             }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
@@ -29,7 +29,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                 testData.DownstreamSwagger.ToString(),
                 testData.Routes,
                 testData.HostOverride,
-                testData.TakeServersFromDownstreamService);
+                new SwaggerEndPointOptions(){ TakeServersFromDownstreamService = testData.TakeServersFromDownstreamService});
 
             AreEqual(transformed, testData.ExpectedTransformedSwagger, testData.FileName);
         }

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotShould.cs
@@ -20,8 +20,10 @@ namespace MMLib.SwaggerForOcelot.Tests
         {
             var options = new OcelotSwaggerGenOptions();
 
-            foreach (var mapping in testData.AuthenticationProviderKeyMap)
-                options.AuthenticationProviderKeyMap.Add(mapping.Key, mapping.Value);
+            foreach ((string key, string value) in testData.AuthenticationProviderKeyMap)
+            {
+                options.AuthenticationProviderKeyMap.Add(key, value);
+            }
 
             var transformer = new SwaggerJsonTransformer(options);
 
@@ -29,7 +31,11 @@ namespace MMLib.SwaggerForOcelot.Tests
                 testData.DownstreamSwagger.ToString(),
                 testData.Routes,
                 testData.HostOverride,
-                new SwaggerEndPointOptions(){ TakeServersFromDownstreamService = testData.TakeServersFromDownstreamService});
+                new SwaggerEndPointOptions()
+                {
+                    TakeServersFromDownstreamService = testData.TakeServersFromDownstreamService,
+                    RemoveUnusedComponentsFromScheme = testData.RemoveUnusedComponentsFromScheme
+                });
 
             AreEqual(transformed, testData.ExpectedTransformedSwagger, testData.FileName);
         }

--- a/tests/MMLib.SwaggerForOcelot.Tests/TestCase.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/TestCase.cs
@@ -47,6 +47,11 @@ namespace MMLib.SwaggerForOcelot.Tests
         /// </value>
         public bool TakeServersFromDownstreamService { get; set; } = false;
 
+        /// <summary>
+        /// Indicating if can remove unused components from downstream docs in this test case.
+        /// </summary>
+        public bool RemoveUnusedComponentsFromScheme { get; set; } = true;
+
         public Dictionary<string, string> AuthenticationProviderKeyMap { get; set; } = new();
 
         /// <summary>

--- a/tests/MMLib.SwaggerForOcelot.Tests/Tests/DoNotRemoveUnusedComponents.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Tests/DoNotRemoveUnusedComponents.json
@@ -1,0 +1,1642 @@
+{
+    "name": "Do not remove unused components.",
+    "description": "Ocelot filter only POST methods.",
+    "hostOverride": "",
+    "routes": [
+        {
+            "DownstreamPathTemplate": "/v2/{everything}",
+            "UpstreamPathTemplate": "/v2/api/pets/{everything}",
+            "UpstreamHttpMethod": [
+                "POST"
+            ],
+            "SwaggerKey": "pets"
+        }
+    ],
+    "removeUnusedComponentsFromScheme": false,
+    "downstreamSwagger": {
+        "swagger": "2.0",
+        "info": {
+            "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+            "version": "1.0.0",
+            "title": "Swagger Petstore",
+            "termsOfService": "http://swagger.io/terms/",
+            "contact": {
+                "email": "apiteam@swagger.io"
+            },
+            "license": {
+                "name": "Apache 2.0",
+                "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+            }
+        },
+        "host": "petstore.swagger.io",
+        "basePath": "/v2",
+        "tags": [
+            {
+                "name": "pet",
+                "description": "Everything about your Pets",
+                "externalDocs": {
+                    "description": "Find out more",
+                    "url": "http://swagger.io"
+                }
+            },
+            {
+                "name": "store",
+                "description": "Access to Petstore orders"
+            },
+            {
+                "name": "user",
+                "description": "Operations about user",
+                "externalDocs": {
+                    "description": "Find out more about our store",
+                    "url": "http://swagger.io"
+                }
+            }
+        ],
+        "schemes": [
+            "https",
+            "http"
+        ],
+        "paths": {
+            "/pet": {
+                "post": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Add a new pet to the store",
+                    "description": "",
+                    "operationId": "addPet",
+                    "consumes": [
+                        "application/json",
+                        "application/xml"
+                    ],
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "Pet object that needs to be added to the store",
+                            "required": true,
+                            "schema": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "405": {
+                            "description": "Invalid input"
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                },
+                "put": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Update an existing pet",
+                    "description": "",
+                    "operationId": "updatePet",
+                    "consumes": [
+                        "application/json",
+                        "application/xml"
+                    ],
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "Pet object that needs to be added to the store",
+                            "required": true,
+                            "schema": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "400": {
+                            "description": "Invalid ID supplied"
+                        },
+                        "404": {
+                            "description": "Pet not found"
+                        },
+                        "405": {
+                            "description": "Validation exception"
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "/pet/findByStatus": {
+                "get": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Finds Pets by status",
+                    "description": "Multiple status values can be provided with comma separated strings",
+                    "operationId": "findPetsByStatus",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "status",
+                            "in": "query",
+                            "description": "Status values that need to be considered for filter",
+                            "required": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "available",
+                                    "pending",
+                                    "sold"
+                                ],
+                                "default": "available"
+                            },
+                            "collectionFormat": "multi"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/Pet"
+                                }
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid status value"
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "/pet/findByTags": {
+                "get": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Finds Pets by tags",
+                    "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+                    "operationId": "findPetsByTags",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "tags",
+                            "in": "query",
+                            "description": "Tags to filter by",
+                            "required": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "collectionFormat": "multi"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/Pet"
+                                }
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid tag value"
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ],
+                    "deprecated": true
+                }
+            },
+            "/pet/{petId}": {
+                "get": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Find pet by ID",
+                    "description": "Returns a single pet",
+                    "operationId": "getPetById",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "description": "ID of pet to return",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid ID supplied"
+                        },
+                        "404": {
+                            "description": "Pet not found"
+                        }
+                    },
+                    "security": [
+                        {
+                            "api_key": []
+                        }
+                    ]
+                },
+                "post": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Updates a pet in the store with form data",
+                    "description": "",
+                    "operationId": "updatePetWithForm",
+                    "consumes": [
+                        "application/x-www-form-urlencoded"
+                    ],
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "description": "ID of pet that needs to be updated",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        {
+                            "name": "name",
+                            "in": "formData",
+                            "description": "Updated name of the pet",
+                            "required": false,
+                            "type": "string"
+                        },
+                        {
+                            "name": "status",
+                            "in": "formData",
+                            "description": "Updated status of the pet",
+                            "required": false,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "405": {
+                            "description": "Invalid input"
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                },
+                "delete": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Deletes a pet",
+                    "description": "",
+                    "operationId": "deletePet",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "api_key",
+                            "in": "header",
+                            "required": false,
+                            "type": "string"
+                        },
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "description": "Pet id to delete",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    ],
+                    "responses": {
+                        "400": {
+                            "description": "Invalid ID supplied"
+                        },
+                        "404": {
+                            "description": "Pet not found"
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "/pet/{petId}/uploadImage": {
+                "post": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "uploads an image",
+                    "description": "",
+                    "operationId": "uploadFile",
+                    "consumes": [
+                        "multipart/form-data"
+                    ],
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "description": "ID of pet to update",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        {
+                            "name": "additionalMetadata",
+                            "in": "formData",
+                            "description": "Additional data to pass to server",
+                            "required": false,
+                            "type": "string"
+                        },
+                        {
+                            "name": "file",
+                            "in": "formData",
+                            "description": "file to upload",
+                            "required": false,
+                            "type": "file"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "$ref": "#/definitions/ApiResponse"
+                            }
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "/store/inventory": {
+                "get": {
+                    "tags": [
+                        "store"
+                    ],
+                    "summary": "Returns pet inventories by status",
+                    "description": "Returns a map of status codes to quantities",
+                    "operationId": "getInventory",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                }
+                            }
+                        }
+                    },
+                    "security": [
+                        {
+                            "api_key": []
+                        }
+                    ]
+                }
+            },
+            "/store/order": {
+                "post": {
+                    "tags": [
+                        "store"
+                    ],
+                    "summary": "Place an order for a pet",
+                    "description": "",
+                    "operationId": "placeOrder",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "order placed for purchasing the pet",
+                            "required": true,
+                            "schema": {
+                                "$ref": "#/definitions/Order"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "$ref": "#/definitions/Order"
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid Order"
+                        }
+                    }
+                }
+            },
+            "/store/order/{orderId}": {
+                "get": {
+                    "tags": [
+                        "store"
+                    ],
+                    "summary": "Find purchase order by ID",
+                    "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+                    "operationId": "getOrderById",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "orderId",
+                            "in": "path",
+                            "description": "ID of pet that needs to be fetched",
+                            "required": true,
+                            "type": "integer",
+                            "maximum": 10.0,
+                            "minimum": 1.0,
+                            "format": "int64"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "$ref": "#/definitions/Order"
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid ID supplied"
+                        },
+                        "404": {
+                            "description": "Order not found"
+                        }
+                    }
+                },
+                "delete": {
+                    "tags": [
+                        "store"
+                    ],
+                    "summary": "Delete purchase order by ID",
+                    "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+                    "operationId": "deleteOrder",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "orderId",
+                            "in": "path",
+                            "description": "ID of the order that needs to be deleted",
+                            "required": true,
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "format": "int64"
+                        }
+                    ],
+                    "responses": {
+                        "400": {
+                            "description": "Invalid ID supplied"
+                        },
+                        "404": {
+                            "description": "Order not found"
+                        }
+                    }
+                }
+            },
+            "/user": {
+                "post": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Create user",
+                    "description": "This can only be done by the logged in user.",
+                    "operationId": "createUser",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "Created user object",
+                            "required": true,
+                            "schema": {
+                                "$ref": "#/definitions/User"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "default": {
+                            "description": "successful operation"
+                        }
+                    }
+                }
+            },
+            "/user/createWithArray": {
+                "post": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Creates list of users with given input array",
+                    "description": "",
+                    "operationId": "createUsersWithArrayInput",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "List of user object",
+                            "required": true,
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/User"
+                                }
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "default": {
+                            "description": "successful operation"
+                        }
+                    }
+                }
+            },
+            "/user/createWithList": {
+                "post": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Creates list of users with given input array",
+                    "description": "",
+                    "operationId": "createUsersWithListInput",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "List of user object",
+                            "required": true,
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/User"
+                                }
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "default": {
+                            "description": "successful operation"
+                        }
+                    }
+                }
+            },
+            "/user/login": {
+                "get": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Logs user into the system",
+                    "description": "",
+                    "operationId": "loginUser",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "username",
+                            "in": "query",
+                            "description": "The user name for login",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "password",
+                            "in": "query",
+                            "description": "The password for login in clear text",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "type": "string"
+                            },
+                            "headers": {
+                                "X-Rate-Limit": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "description": "calls per hour allowed by the user"
+                                },
+                                "X-Expires-After": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "date in UTC when token expires"
+                                }
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid username/password supplied"
+                        }
+                    }
+                }
+            },
+            "/user/logout": {
+                "get": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Logs out current logged in user session",
+                    "description": "",
+                    "operationId": "logoutUser",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "default": {
+                            "description": "successful operation"
+                        }
+                    }
+                }
+            },
+            "/user/{username}": {
+                "get": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Get user by user name",
+                    "description": "",
+                    "operationId": "getUserByName",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "username",
+                            "in": "path",
+                            "description": "The name that needs to be fetched. Use user1 for testing. ",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "$ref": "#/definitions/User"
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid username supplied"
+                        },
+                        "404": {
+                            "description": "User not found"
+                        }
+                    }
+                },
+                "put": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Updated user",
+                    "description": "This can only be done by the logged in user.",
+                    "operationId": "updateUser",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "username",
+                            "in": "path",
+                            "description": "name that need to be updated",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "Updated user object",
+                            "required": true,
+                            "schema": {
+                                "$ref": "#/definitions/User"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "400": {
+                            "description": "Invalid user supplied"
+                        },
+                        "404": {
+                            "description": "User not found"
+                        }
+                    }
+                },
+                "delete": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Delete user",
+                    "description": "This can only be done by the logged in user.",
+                    "operationId": "deleteUser",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "username",
+                            "in": "path",
+                            "description": "The name that needs to be deleted",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "400": {
+                            "description": "Invalid username supplied"
+                        },
+                        "404": {
+                            "description": "User not found"
+                        }
+                    }
+                }
+            }
+        },
+        "securityDefinitions": {
+            "petstore_auth": {
+                "type": "oauth2",
+                "authorizationUrl": "https://petstore.swagger.io/oauth/authorize",
+                "flow": "implicit",
+                "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                }
+            },
+            "api_key": {
+                "type": "apiKey",
+                "name": "api_key",
+                "in": "header"
+            }
+        },
+        "definitions": {
+            "Order": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "petId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "quantity": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "shipDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Order Status",
+                        "enum": [
+                            "placed",
+                            "approved",
+                            "delivered"
+                        ]
+                    },
+                    "complete": {
+                        "type": "boolean",
+                        "default": false
+                    }
+                },
+                "xml": {
+                    "name": "Order"
+                }
+            },
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "userStatus": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "User Status"
+                    }
+                },
+                "xml": {
+                    "name": "User"
+                }
+            },
+            "Category": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "xml": {
+                    "name": "Category"
+                }
+            },
+            "Tag": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "xml": {
+                    "name": "Tag"
+                }
+            },
+            "Pet": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "photoUrls"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "category": {
+                        "$ref": "#/definitions/Category"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "doggie"
+                    },
+                    "photoUrls": {
+                        "type": "array",
+                        "xml": {
+                            "name": "photoUrl",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "xml": {
+                            "name": "tag",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "$ref": "#/definitions/Tag"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "pet status in the store",
+                        "enum": [
+                            "available",
+                            "pending",
+                            "sold"
+                        ]
+                    }
+                },
+                "xml": {
+                    "name": "Pet"
+                }
+            },
+            "ApiResponse": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "NoUsedOrder": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "petId": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "shipDate": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "status": {
+                "type": "string",
+                "description": "Order Status",
+                "enum": [
+                  "placed",
+                  "approved",
+                  "delivered"
+                ]
+              },
+              "complete": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "xml": {
+              "name": "Order"
+            }
+          }
+        },
+        "externalDocs": {
+            "description": "Find out more about Swagger",
+            "url": "http://swagger.io"
+        }
+    },
+    "expectedTransformedSwagger": {
+        "swagger": "2.0",
+        "info": {
+            "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+            "version": "1.0.0",
+            "title": "Swagger Petstore",
+            "termsOfService": "http://swagger.io/terms/",
+            "contact": {
+                "email": "apiteam@swagger.io"
+            },
+            "license": {
+                "name": "Apache 2.0",
+                "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+            }
+        },
+        "basePath": "/",
+        "tags": [
+            {
+                "name": "pet",
+                "description": "Everything about your Pets",
+                "externalDocs": {
+                    "description": "Find out more",
+                    "url": "http://swagger.io"
+                }
+            },
+            {
+                "name": "store",
+                "description": "Access to Petstore orders"
+            },
+            {
+                "name": "user",
+                "description": "Operations about user",
+                "externalDocs": {
+                    "description": "Find out more about our store",
+                    "url": "http://swagger.io"
+                }
+            }
+        ],
+        "paths": {
+            "/v2/api/pets/pet": {
+                "post": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Add a new pet to the store",
+                    "description": "",
+                    "operationId": "addPet",
+                    "consumes": [
+                        "application/json",
+                        "application/xml"
+                    ],
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "Pet object that needs to be added to the store",
+                            "required": true,
+                            "schema": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "405": {
+                            "description": "Invalid input"
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "/v2/api/pets/pet/{petId}": {
+                "post": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "Updates a pet in the store with form data",
+                    "description": "",
+                    "operationId": "updatePetWithForm",
+                    "consumes": [
+                        "application/x-www-form-urlencoded"
+                    ],
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "description": "ID of pet that needs to be updated",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        {
+                            "name": "name",
+                            "in": "formData",
+                            "description": "Updated name of the pet",
+                            "required": false,
+                            "type": "string"
+                        },
+                        {
+                            "name": "status",
+                            "in": "formData",
+                            "description": "Updated status of the pet",
+                            "required": false,
+                            "type": "string"
+                        }
+                    ],
+                    "responses": {
+                        "405": {
+                            "description": "Invalid input"
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "/v2/api/pets/pet/{petId}/uploadImage": {
+                "post": {
+                    "tags": [
+                        "pet"
+                    ],
+                    "summary": "uploads an image",
+                    "description": "",
+                    "operationId": "uploadFile",
+                    "consumes": [
+                        "multipart/form-data"
+                    ],
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "description": "ID of pet to update",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        {
+                            "name": "additionalMetadata",
+                            "in": "formData",
+                            "description": "Additional data to pass to server",
+                            "required": false,
+                            "type": "string"
+                        },
+                        {
+                            "name": "file",
+                            "in": "formData",
+                            "description": "file to upload",
+                            "required": false,
+                            "type": "file"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "$ref": "#/definitions/ApiResponse"
+                            }
+                        }
+                    },
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "/v2/api/pets/store/order": {
+                "post": {
+                    "tags": [
+                        "store"
+                    ],
+                    "summary": "Place an order for a pet",
+                    "description": "",
+                    "operationId": "placeOrder",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "order placed for purchasing the pet",
+                            "required": true,
+                            "schema": {
+                                "$ref": "#/definitions/Order"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "successful operation",
+                            "schema": {
+                                "$ref": "#/definitions/Order"
+                            }
+                        },
+                        "400": {
+                            "description": "Invalid Order"
+                        }
+                    }
+                }
+            },
+            "/v2/api/pets/user": {
+                "post": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Create user",
+                    "description": "This can only be done by the logged in user.",
+                    "operationId": "createUser",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "Created user object",
+                            "required": true,
+                            "schema": {
+                                "$ref": "#/definitions/User"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "default": {
+                            "description": "successful operation"
+                        }
+                    }
+                }
+            },
+            "/v2/api/pets/user/createWithArray": {
+                "post": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Creates list of users with given input array",
+                    "description": "",
+                    "operationId": "createUsersWithArrayInput",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "List of user object",
+                            "required": true,
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/User"
+                                }
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "default": {
+                            "description": "successful operation"
+                        }
+                    }
+                }
+            },
+            "/v2/api/pets/user/createWithList": {
+                "post": {
+                    "tags": [
+                        "user"
+                    ],
+                    "summary": "Creates list of users with given input array",
+                    "description": "",
+                    "operationId": "createUsersWithListInput",
+                    "produces": [
+                        "application/xml",
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "description": "List of user object",
+                            "required": true,
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/User"
+                                }
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "default": {
+                            "description": "successful operation"
+                        }
+                    }
+                }
+            }
+        },
+        "securityDefinitions": {
+            "petstore_auth": {
+                "type": "oauth2",
+                "authorizationUrl": "https://petstore.swagger.io/oauth/authorize",
+                "flow": "implicit",
+                "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                }
+            },
+            "api_key": {
+                "type": "apiKey",
+                "name": "api_key",
+                "in": "header"
+            }
+        },
+        "definitions": {
+            "Order": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "petId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "quantity": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "shipDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Order Status",
+                        "enum": [
+                            "placed",
+                            "approved",
+                            "delivered"
+                        ]
+                    },
+                    "complete": {
+                        "type": "boolean",
+                        "default": false
+                    }
+                },
+                "xml": {
+                    "name": "Order"
+                }
+            },
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "userStatus": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "User Status"
+                    }
+                },
+                "xml": {
+                    "name": "User"
+                }
+            },
+            "Category": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "xml": {
+                    "name": "Category"
+                }
+            },
+            "Tag": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "xml": {
+                    "name": "Tag"
+                }
+            },
+            "Pet": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "photoUrls"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "category": {
+                        "$ref": "#/definitions/Category"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "doggie"
+                    },
+                    "photoUrls": {
+                        "type": "array",
+                        "xml": {
+                            "name": "photoUrl",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "xml": {
+                            "name": "tag",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "$ref": "#/definitions/Tag"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "pet status in the store",
+                        "enum": [
+                            "available",
+                            "pending",
+                            "sold"
+                        ]
+                    }
+                },
+                "xml": {
+                    "name": "Pet"
+                }
+            },
+            "ApiResponse": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "NoUsedOrder": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "petId": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "shipDate": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "status": {
+                "type": "string",
+                "description": "Order Status",
+                "enum": [
+                  "placed",
+                  "approved",
+                  "delivered"
+                ]
+              },
+              "complete": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "xml": {
+              "name": "Order"
+            }
+          }
+        },
+        "externalDocs": {
+            "description": "Find out more about Swagger",
+            "url": "http://swagger.io"
+        }
+    }
+}

--- a/tests/MMLib.SwaggerForOcelot.Tests/Tests/OpenApiDoNotRemoveUnusedComponents.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Tests/OpenApiDoNotRemoveUnusedComponents.json
@@ -1,0 +1,393 @@
+{
+    "name": "Open api version with basic configuration.",
+    "description": "Test open api format with basic configuration.",
+    "hostOverride": "localhost:8000",
+    "removeUnusedComponentsFromScheme": false,
+    "routes": [
+        {
+            "DownstreamPathTemplate": "/api/{everything}",
+            "UpstreamPathTemplate": "/api/projects/{everything}",
+            "SwaggerKey": "projects"
+        }
+    ],
+    "downstreamSwagger": {
+        "openapi": "3.0",
+        "info": {
+            "version": "v1",
+            "title": "Projects API"
+        },
+        "paths": {
+            "/api/Projects": {
+                "get": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "uniqueItems": false,
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Project"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/api/Projects/{id}": {
+                "get": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "$ref": "#/components/schemas/Project"
+                            }
+                        },
+                        "404": {
+                            "description": "Not Found"
+                        }
+                    }
+                }
+            },
+            "/api/Projects/projectCreate": {
+                "post": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "CreateProject",
+                    "consumes": [
+                        "application/json-patch+json",
+                        "application/json",
+                        "text/json",
+                        "application/*+json"
+                    ],
+                    "produces": [],
+                    "parameters": [
+                        {
+                            "name": "projectViewModel",
+                            "in": "body",
+                            "required": false,
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectViewModel"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "201": {
+                            "description": "Success"
+                        },
+                        "400": {
+                            "description": "Bad Request"
+                        }
+                    }
+                }
+            },
+            "/api/Values": {
+                "get": {
+                    "tags": [
+                        "Values"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "uniqueItems": false,
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Project": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "owner": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "UnusedProject": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "ProjectViewModel": {
+                    "required": [
+                        "name",
+                        "owner"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "maxLength": 50,
+                            "type": "string"
+                        },
+                        "description": {
+                            "maxLength": 255,
+                            "type": "string"
+                        },
+                        "owner": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "expectedTransformedSwagger": {
+        "openapi": "3.0",
+        "info": {
+            "version": "v1",
+            "title": "Projects API"
+        },
+        "paths": {
+            "/api/projects/Projects": {
+                "get": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "uniqueItems": false,
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Project"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/api/projects/Projects/{id}": {
+                "get": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "$ref": "#/components/schemas/Project"
+                            }
+                        },
+                        "404": {
+                            "description": "Not Found"
+                        }
+                    }
+                }
+            },
+            "/api/projects/Projects/projectCreate": {
+                "post": {
+                    "tags": [
+                        "Projects"
+                    ],
+                    "operationId": "CreateProject",
+                    "consumes": [
+                        "application/json-patch+json",
+                        "application/json",
+                        "text/json",
+                        "application/*+json"
+                    ],
+                    "produces": [],
+                    "parameters": [
+                        {
+                            "name": "projectViewModel",
+                            "in": "body",
+                            "required": false,
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectViewModel"
+                            }
+                        }
+                    ],
+                    "responses": {
+                        "201": {
+                            "description": "Success"
+                        },
+                        "400": {
+                            "description": "Bad Request"
+                        }
+                    }
+                }
+            },
+            "/api/projects/Values": {
+                "get": {
+                    "tags": [
+                        "Values"
+                    ],
+                    "operationId": "Get",
+                    "consumes": [],
+                    "produces": [
+                        "text/plain",
+                        "application/json",
+                        "text/json"
+                    ],
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "uniqueItems": false,
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Project": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "owner": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "UnusedProject": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "ProjectViewModel": {
+                    "required": [
+                        "name",
+                        "owner"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "maxLength": 50,
+                            "type": "string"
+                        },
+                        "description": {
+                            "maxLength": 255,
+                            "type": "string"
+                        },
+                        "owner": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
If your downstream documentation is too large (usually more than 10 MB), the response may be too slow. You can turn off the removal of an unused schema component from downstream documentation by using `RemoveUnusedComponentsFromScheme: false`.
```csharp
 "SwaggerEndPoints": [
    {
      "Key": "projects",
      "RemoveUnusedComponentsFromScheme": false,
      "Config": [
        {
          "Name": "Projects API",
          "Version": "v1",
          "Service": {
            "Name": "projects",
            "Path": "/swagger/v1/swagger.json"
          }
        }
      ]
    }
  ]
```