### PR TITLE
Support SwaggerUI configuration reload after ocelot.json change

### DIFF
--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
@@ -38,9 +38,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddTransient<IDownstreamSwaggerDocsRepository, DownstreamSwaggerDocsRepository>()
                 .AddTransient<ISwaggerServiceDiscoveryProvider, SwaggerServiceDiscoveryProvider>()
                 .AddTransient<ISwaggerJsonTransformer, SwaggerJsonTransformer>()
-                .Configure<List<RouteOptions>>(options => configuration.GetSection("Routes").Bind(options))
-                .Configure<List<SwaggerEndPointOptions>>(options
-                    => configuration.GetSection(SwaggerEndPointOptions.ConfigurationSectionName).Bind(options))
+                .Configure<List<RouteOptions>>(configuration.GetSection("Routes"))
+                .Configure<List<SwaggerEndPointOptions>>(configuration.GetSection(SwaggerEndPointOptions.ConfigurationSectionName))
                 .AddHttpClient()
                 .AddMemoryCache()
                 .AddSingleton<ISwaggerEndPointProvider, SwaggerEndPointProvider>();

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>4.8.0</Version>
+    <Version>4.9.0</Version>
     <Authors>Milan Martiniak</Authors>
     <Company>MMLib</Company>
     <Description>Swagger generator for Ocelot downstream services.</Description>

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -27,7 +27,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
         private readonly RequestDelegate _next;
 #pragma warning restore IDE0052
 
-        private readonly IOptions<List<RouteOptions>> _routes;
+        private readonly IOptionsMonitor<List<RouteOptions>> _routes;
         private readonly ISwaggerJsonTransformer _transformer;
         private readonly SwaggerForOcelotUIOptions _options;
         private readonly ISwaggerDownstreamInterceptor _downstreamInterceptor;
@@ -45,7 +45,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
         public SwaggerForOcelotMiddleware(
             RequestDelegate next,
             SwaggerForOcelotUIOptions options,
-            IOptions<List<RouteOptions>> routes,
+            IOptionsMonitor<List<RouteOptions>> routes,
             ISwaggerJsonTransformer transformer,
             ISwaggerProvider swaggerProvider,
             ISwaggerDownstreamInterceptor downstreamInterceptor = null)
@@ -85,7 +85,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
                 return;
             }
 
-            IEnumerable<RouteOptions> routeOptions = _routes.Value
+            IEnumerable<RouteOptions> routeOptions = _routes.CurrentValue
                 .ExpandConfig(endPoint)
                 .GroupByPaths();
 

--- a/src/MMLib.SwaggerForOcelot/Repositories/SwaggerEndPointProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/Repositories/SwaggerEndPointProvider.cs
@@ -13,7 +13,7 @@ namespace MMLib.SwaggerForOcelot.Repositories
     public class SwaggerEndPointProvider : ISwaggerEndPointProvider
     {
         private readonly Lazy<Dictionary<string, SwaggerEndPointOptions>> _swaggerEndPoints;
-        private readonly IOptions<List<SwaggerEndPointOptions>> _swaggerEndPointsOptions;
+        private readonly IOptionsMonitor<List<SwaggerEndPointOptions>> _swaggerEndPointsOptions;
         private readonly OcelotSwaggerGenOptions _options;
 
         /// <summary>
@@ -21,7 +21,7 @@ namespace MMLib.SwaggerForOcelot.Repositories
         /// </summary>
         /// <param name="swaggerEndPoints">The swagger end points.</param>
         public SwaggerEndPointProvider(
-            IOptions<List<SwaggerEndPointOptions>> swaggerEndPoints,
+            IOptionsMonitor<List<SwaggerEndPointOptions>> swaggerEndPoints,
             OcelotSwaggerGenOptions options)
         {
             _swaggerEndPointsOptions = Check.NotNull(swaggerEndPoints, nameof(swaggerEndPoints));
@@ -40,7 +40,7 @@ namespace MMLib.SwaggerForOcelot.Repositories
 
         private Dictionary<string, SwaggerEndPointOptions> Init()
         {
-            var ret = _swaggerEndPointsOptions.Value.ToDictionary(p => $"/{p.KeyToPath}", p => p);
+            var ret = _swaggerEndPointsOptions.CurrentValue.ToDictionary(p => $"/{p.KeyToPath}", p => p);
 
             if (_options.GenerateDocsForAggregates)
             {

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -40,14 +40,14 @@ namespace MMLib.SwaggerForOcelot.Tests
 
             // What is being tested
             var swaggerForOcelotOptions = new SwaggerForOcelotUIOptions();
-            TestSwaggerEndpointOptions swaggerEndpointOptions = CreateSwaggerEndpointOptions(key,version);
+            TestSwaggerEndpointOptions swaggerEndpointOptions = CreateSwaggerEndpointOptions(key, version);
             var routeOptions = new TestRouteOptions(new List<RouteOptions>
             {
                 new()
                 {
                     SwaggerKey = "projects",
-                    UpstreamPathTemplate ="/api/{version}/projects/Values/{everything}",
-                    DownstreamPathTemplate ="/api/{version}/Values/{everything}",
+                    UpstreamPathTemplate = "/api/{version}/projects/Values/{everything}",
+                    DownstreamPathTemplate = "/api/{version}/Values/{everything}",
                 },
                 new()
                 {
@@ -83,7 +83,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                     IEnumerable<RouteOptions> routeOptions,
                     string serverOverride,
                     SwaggerEndPointOptions options) => new SwaggerJsonTransformer(OcelotSwaggerGenOptions.Default)
-                    .Transform(swaggerJson,routeOptions, serverOverride, options));
+                    .Transform(swaggerJson, routeOptions, serverOverride, options));
             var swaggerForOcelotMiddleware = new SwaggerForOcelotMiddleware(
                 next.Invoke,
                 swaggerForOcelotOptions,
@@ -105,6 +105,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                 string transformedUpstreamSwagger = await streamReader.ReadToEndAsync();
                 AreEqual(transformedUpstreamSwagger, expectedSwagger);
             }
+
             swaggerJsonTransformerMock.Verify(x => x.Transform(
                 It.IsAny<string>(),
                 It.IsAny<IEnumerable<RouteOptions>>(),
@@ -127,7 +128,7 @@ namespace MMLib.SwaggerForOcelot.Tests
             {
                 ReConfigureUpstreamSwaggerJson = ExampleUserDefinedUpstreamTransformer
             };
-            TestSwaggerEndpointOptions testSwaggerEndpointOptions = CreateSwaggerEndpointOptions(key,version);
+            TestSwaggerEndpointOptions testSwaggerEndpointOptions = CreateSwaggerEndpointOptions(key, version);
             var routeOptions = new TestRouteOptions();
 
             // downstreamSwagger is returned when client.GetStringAsync is called by the middleware.
@@ -171,7 +172,7 @@ namespace MMLib.SwaggerForOcelot.Tests
 
             // What is being tested
             var swaggerForOcelotOptions = new SwaggerForOcelotUIOptions();
-            TestSwaggerEndpointOptions swaggerEndpointOptions = CreateSwaggerEndpointOptions(key,version);
+            TestSwaggerEndpointOptions swaggerEndpointOptions = CreateSwaggerEndpointOptions(key, version);
             var routeOptions = new TestRouteOptions(new List<RouteOptions>
             {
                 new()
@@ -308,10 +309,7 @@ namespace MMLib.SwaggerForOcelot.Tests
                 )
                 .ReturnsAsync((HttpRequestMessage request, CancellationToken token) =>
                 {
-                    var response = new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new StringContent(downstreamSwagger)
-                    };
+                    var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(downstreamSwagger) };
                     return response;
                 });
             return new HttpClient(httpMessageHandlerMock.Object);
@@ -349,6 +347,7 @@ namespace MMLib.SwaggerForOcelot.Tests
             {
                 _mockHttpClient = mockHttpClient;
             }
+
             public HttpClient CreateClient()
             {
                 return _mockHttpClient;
@@ -360,28 +359,38 @@ namespace MMLib.SwaggerForOcelot.Tests
             }
         }
 
-        private class TestRouteOptions : IOptions<List<RouteOptions>>
+        private class TestRouteOptions : IOptionsMonitor<List<RouteOptions>>
         {
             public TestRouteOptions()
             {
-                Value = new List<RouteOptions>();
+                CurrentValue = new List<RouteOptions>();
             }
 
             public TestRouteOptions(List<RouteOptions> value)
             {
-                Value = value;
+                CurrentValue = value;
             }
 
-            public List<RouteOptions> Value { get; }
+            public List<RouteOptions> Get(string name) => throw new NotImplementedException();
+
+            public IDisposable OnChange(Action<List<RouteOptions>, string> listener) => throw new NotImplementedException();
+
+            public List<RouteOptions> CurrentValue { get; }
         }
 
-        private class TestSwaggerEndpointOptions : IOptions<List<SwaggerEndPointOptions>>
+        private class TestSwaggerEndpointOptions : IOptionsMonitor<List<SwaggerEndPointOptions>>
         {
             public TestSwaggerEndpointOptions(List<SwaggerEndPointOptions> options)
             {
-                Value = options;
+                CurrentValue = options;
             }
-            public List<SwaggerEndPointOptions> Value { get; }
+
+            public List<SwaggerEndPointOptions> Get(string name) => throw new NotImplementedException();
+
+            public IDisposable OnChange(Action<List<SwaggerEndPointOptions>, string> listener) =>
+                throw new NotImplementedException();
+
+            public List<SwaggerEndPointOptions> CurrentValue { get; }
         }
 
         private class TestSwaggerJsonTransformer : ISwaggerJsonTransformer


### PR DESCRIPTION
close #224

When you mark the `ocelot.json` configuration as `reloadOnChange:true`

```csharp
.AddJsonFile($"ocelot.json", optional: false, reloadOnChange: true)
```

then the swagger specification will reflect changes to this file without having to restart the Ocelot service.