### PR TITLE
Fix hot reload for Swagger documentation

### DIFF
--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Configure<List<SwaggerEndPointOptions>>(configuration.GetSection(SwaggerEndPointOptions.ConfigurationSectionName))
                 .AddHttpClient()
                 .AddMemoryCache()
-                .AddSingleton<ISwaggerEndPointProvider, SwaggerEndPointProvider>();
+                .AddTransient<ISwaggerEndPointProvider, SwaggerEndPointProvider>();
 
             services.AddHttpClient(IgnoreSslCertificate, c =>
             {


### PR DESCRIPTION
Issue #224 - Fix Swagger documentation hot reload.

Issue details: 
Hi @Burgyn , it seems that we still have an issue here. The hot reload is working now, the ocelot.json is reloaded and all the endpoints are accessible trough the Ocelot gateway. But the swagger documentation for all "hot reloaded" endpoints is not accessible. We can see it in the endpoint list in swagger but after selecting it the page is not loading and we receive a 500 response.

PS. If we restart the Ocelot service, swagger is accessible for hot reloaded endpoints.

Do you have any ideas? Thank you!

Later edit:
We observed that SwaggerEndpointRepository contains _swaggerEndPoints and _swaggerEndpointsOptions. It seems that _swaggerEndPoints it's not updated and contains 12 endpoints (old value before hot reload) and swaggerEndpointsOptions contains the correct number of endpoints after hot reload (13).
image

Info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
Request starting HTTP/2 GET https://localhost:33555/swagger/docs/v4.0/batches - -
fail: Microsoft.AspNetCore.Server.Kestrel[13]
Connection id "0HMHNT5C1AJVQ", Request id "0HMHNT5C1AJVQ:0000000B": An unhandled exception was thrown by the application.
System.Collections.Generic.KeyNotFoundException: The given key '/batches' was not present in the dictionary.
at System.Collections.Generic.Dictionary2.get_Item(TKey key) at MMLib.SwaggerForOcelot.Repositories.SwaggerEndPointProvider.GetByKey(String key) at MMLib.SwaggerForOcelot.Middleware.SwaggerForOcelotMiddleware.GetEndPoint(String path, ISwaggerEndPointProvider swaggerEndPointRepository) at MMLib.SwaggerForOcelot.Middleware.SwaggerForOcelotMiddleware.Invoke(HttpContext context, ISwaggerEndPointProvider swaggerEndPointRepository, IDownstreamSwaggerDocsRepository downstreamSwaggerDocs) at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext) at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context) at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext) at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext) at Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context) at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext) at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication1 application)
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
