### PR TITLE
Add better support for customizing SwaggerUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ app.UseSwaggerForOcelotUI(opt => {
 })
   ```
 
+You can optionally customize SwaggerUI:
+```CSharp
+app.UseSwaggerForOcelotUI(opt => {
+    // swaggerForOcelot options
+}, uiOpt => {
+    //swaggerUI options
+    uiOpt.DocumentTitle = "Gateway documentation";
+})
+  ```
+
 6. Show your microservices interactive documentation.
 
    > `http://ocelotserviceurl/swagger`

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -10,7 +10,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
     /// Configuration for Swagger UI.
     /// </summary>
     /// <seealso cref="Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIOptions" />
-    public class SwaggerForOcelotUIOptions : SwaggerUIOptions
+    public class SwaggerForOcelotUIOptions
     {
         /// <summary>
         /// The relative path to gateway swagger generator.

--- a/src/MMLib.SwaggerForOcelot/Middleware/BuilderExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/BuilderExtensions.cs
@@ -20,12 +20,14 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         /// <param name="app">The application builder.</param>
         /// <param name="setupAction">Setup <see cref="SwaggerForOcelotUIOptions"/></param>
+        /// <param name="setupUiAction">Setup SwaggerUI</param>
         /// <returns>
         /// <see cref="IApplicationBuilder"/>.
         /// </returns>
         public static IApplicationBuilder UseSwaggerForOcelotUI(
             this IApplicationBuilder app,
-            Action<SwaggerForOcelotUIOptions> setupAction = null)
+            Action<SwaggerForOcelotUIOptions> setupAction = null,
+            Action<SwaggerUIOptions> setupUiAction = null)
         {
             SwaggerForOcelotUIOptions options = app.ApplicationServices.GetService<IOptions<SwaggerForOcelotUIOptions>>().Value;
             setupAction?.Invoke(options);
@@ -33,7 +35,7 @@ namespace Microsoft.AspNetCore.Builder
 
             app.UseSwaggerUI(c =>
             {
-                InitUIOption(c, options);
+                setupUiAction?.Invoke(c);
                 IReadOnlyList<SwaggerEndPointOptions> endPoints = app
                     .ApplicationServices.GetService<ISwaggerEndPointProvider>().GetAll();
 
@@ -94,16 +96,6 @@ namespace Microsoft.AspNetCore.Builder
                     c.SwaggerEndpoint($"{basePath}/{config.Version}/{endPoint.KeyToPath}", GetDescription(config));
                 }
             }
-        }
-
-        private static void InitUIOption(SwaggerUIOptions c, SwaggerForOcelotUIOptions options)
-        {
-            c.ConfigObject = options.ConfigObject;
-            c.DocumentTitle = options.DocumentTitle;
-            c.HeadContent = options.HeadContent;
-            c.IndexStream = options.IndexStream;
-            c.OAuthConfigObject = options.OAuthConfigObject;
-            c.RoutePrefix = options.RoutePrefix;
         }
     }
 }


### PR DESCRIPTION
I wanted to define some `ResponseInterceptor` for SwaggerUI but it looked like these options were never actually set ([cf. `BuilderExtensions:InitUIOption()`](https://github.com/Burgyn/MMLib.SwaggerForOcelot/blob/0fec51330b79da40db56b2b8eed7214971cb60da/src/MMLib.SwaggerForOcelot/Middleware/BuilderExtensions.cs#L99)).

This PR aims at providing better control over SwaggerUI options by:
- decoupling `SwaggerForOcelotUIOptions` and `SwaggerUIOptions`
- adding a parameter to `UseSwaggerForOcelotUI()` to customize SwaggerUI