### PR TITLE
Add options to override gateway documentation title and openapi information

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ services.AddSwaggerForOcelot(Configuration,
       o.GenerateDocsForGatewayItSelf(opt =>
       {
           opt.FilePathsForXmlComments = { "MyAPI.xml" };
+          docGen.GatewayDocsTitle = "My Gateway";
+          docGen.GatewayDocsOpenApiInfo = new()
+          {
+             Title = "My Gateway",
+             Version = "v1",
+          };
           opt.DocumentFilter<MyDocumentFilter>();
           opt.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme()
           {

--- a/src/MMLib.SwaggerForOcelot/Configuration/OcelotGatewayItSelfSwaggerGenOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/OcelotGatewayItSelfSwaggerGenOptions.cs
@@ -27,6 +27,9 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// </summary>
         public string[] FilePathsForXmlComments { get; set; }
 
+        public string? GatewayDocsTitle { get; set; }
+        public OpenApiInfo? GatewayDocsOpenApiInfo { get; set; }
+
         internal List<Action<SwaggerGenOptions>> DocumentFilterActions { get; }
 
         internal List<Action<SwaggerGenOptions>> OperationFilterActions { get; }

--- a/src/MMLib.SwaggerForOcelot/Configuration/OcelotSwaggerGenOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/OcelotSwaggerGenOptions.cs
@@ -34,7 +34,6 @@ namespace MMLib.SwaggerForOcelot.Configuration
         {
             GenerateDocsForGatewayItSelf = true;
            
-
             OcelotGatewayItSelfSwaggerGenOptions = new OcelotGatewayItSelfSwaggerGenOptions();
             options?.Invoke(OcelotGatewayItSelfSwaggerGenOptions);
 

--- a/src/MMLib.SwaggerForOcelot/Configuration/OcelotSwaggerGenOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/OcelotSwaggerGenOptions.cs
@@ -33,9 +33,13 @@ namespace MMLib.SwaggerForOcelot.Configuration
         public void GenerateDocsDocsForGatewayItSelf(Action<OcelotGatewayItSelfSwaggerGenOptions> options = null)
         {
             GenerateDocsForGatewayItSelf = true;
+           
 
             OcelotGatewayItSelfSwaggerGenOptions = new OcelotGatewayItSelfSwaggerGenOptions();
             options?.Invoke(OcelotGatewayItSelfSwaggerGenOptions);
+
+            GatewayDocsTitle = OcelotGatewayItSelfSwaggerGenOptions.GatewayDocsTitle ?? GatewayDocsTitle;
+            GatewayDocsOpenApiInfo = OcelotGatewayItSelfSwaggerGenOptions.GatewayDocsOpenApiInfo ?? GatewayDocsOpenApiInfo;
         }
 
         /// <summary>
@@ -60,6 +64,14 @@ namespace MMLib.SwaggerForOcelot.Configuration
         internal const string AggregatesKey = "aggregates";
 
         internal const string GatewayKey = "gateway";
+
+        internal string GatewayDocsTitle { get; set; } = "Gateway";
+
+        internal OpenApiInfo GatewayDocsOpenApiInfo { get; set; } = new()
+        {
+            Title = "Gateway",
+            Version = GatewayKey,
+        };
 
         internal OcelotGatewayItSelfSwaggerGenOptions OcelotGatewayItSelfSwaggerGenOptions { get; private set; }
 

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
@@ -85,11 +85,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (options.GenerateDocsForGatewayItSelf)
             {
-                c.SwaggerDoc(OcelotSwaggerGenOptions.GatewayKey, new OpenApiInfo
-                {
-                    Title =  "Gateway",
-                    Version = OcelotSwaggerGenOptions.GatewayKey,
-                });
+                c.SwaggerDoc(OcelotSwaggerGenOptions.GatewayKey, options.GatewayDocsOpenApiInfo);
 
                 if (options.OcelotGatewayItSelfSwaggerGenOptions is not null)
                 {

--- a/src/MMLib.SwaggerForOcelot/Repositories/SwaggerEndPointProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/Repositories/SwaggerEndPointProvider.cs
@@ -49,7 +49,7 @@ namespace MMLib.SwaggerForOcelot.Repositories
 
             if (_options.GenerateDocsForGatewayItSelf)
             {
-                AddEndpoint(ret, OcelotSwaggerGenOptions.GatewayKey, "Gateway");
+                AddEndpoint(ret, OcelotSwaggerGenOptions.GatewayKey, _options.GatewayDocsTitle);
             }
 
             return ret;


### PR DESCRIPTION
This pull request allows users to override the gateway documentation title and forward openapi information.


