### PR TITLE
Add ability to customize internal HttpClient

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -44,8 +44,10 @@ namespace MMLib.SwaggerForOcelot.Configuration
         public string ServerOcelot { get; set; }
 
         /// <summary>
-        /// If set, The given httpclient will be used instead of an internal generated one.
+        /// Replace the internal HttpClient with a custom named client.<br/><br/> When this is set, Some downstream route specific properties will be ignored
+        /// such as <see cref="RouteOptions.DangerousAcceptAnyServerCertificateValidator"/>
+        /// <br/><br/><see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-6.0#named-clients"/>
         /// </summary>
-        public HttpClient? HttpClient { get; set; }
+        public string? HttpClientName { get; set; }
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerForOcelotUIOptions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using System.Net.Http;
 
 namespace MMLib.SwaggerForOcelot.Configuration
 {
@@ -41,5 +42,10 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// Configure route of server of swagger in ocelot.
         /// </summary>
         public string ServerOcelot { get; set; }
+
+        /// <summary>
+        /// If set, The given httpclient will be used instead of an internal generated one.
+        /// </summary>
+        public HttpClient? HttpClient { get; set; }
     }
 }

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -8,7 +8,7 @@
         <Description>Swagger generator for Ocelot downstream services.</Description>
         <PackageProjectUrl>https://github.com/Burgyn/MMLib.SwaggerForOcelot</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
-        <PackageProjectUrl>https://github.com/Burgyn/MMLib.SwaggerForOcelot</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/Burgyn/MMLib.SwaggerForOcelot</RepositoryUrl>
         <PackageTags>swagger;documentation;ocelot</PackageTags>
         <PackageReleaseNotes/>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Version>6.1.0</Version>
+        <Version>6.2.0</Version>
         <Authors>Milan Martiniak</Authors>
         <Company>MMLib</Company>
         <Description>Swagger generator for Ocelot downstream services.</Description>
-        <PackageProjectUrl>https://github.com/Burgyn/MMLib.SwaggerForOcelot</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/Arcalise08/MMLib.SwaggerForOcelot</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
-        <RepositoryUrl>https://github.com/Burgyn/MMLib.SwaggerForOcelot</RepositoryUrl>
+        <RepositoryUrl>https://github.com/Arcalise08/MMLib.SwaggerForOcelot</RepositoryUrl>
         <PackageTags>swagger;documentation;ocelot</PackageTags>
         <PackageReleaseNotes/>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Version>6.2.0</Version>
+        <Version>6.1.0</Version>
         <Authors>Milan Martiniak</Authors>
         <Company>MMLib</Company>
         <Description>Swagger generator for Ocelot downstream services.</Description>
-        <PackageProjectUrl>https://github.com/Arcalise08/MMLib.SwaggerForOcelot</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/Burgyn/MMLib.SwaggerForOcelot</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
-        <RepositoryUrl>https://github.com/Arcalise08/MMLib.SwaggerForOcelot</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/Burgyn/MMLib.SwaggerForOcelot</PackageProjectUrl>
         <PackageTags>swagger;documentation;ocelot</PackageTags>
         <PackageReleaseNotes/>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/MMLib.SwaggerForOcelot/Repositories/DownstreamSwaggerDocsRepository.cs
+++ b/src/MMLib.SwaggerForOcelot/Repositories/DownstreamSwaggerDocsRepository.cs
@@ -43,10 +43,8 @@ namespace MMLib.SwaggerForOcelot.Repositories
             string docsVersion = null)
         {
             string url = await GetUrlAsync(route, endPoint, docsVersion);
-            var clientName = (route?.DangerousAcceptAnyServerCertificateValidator ?? false) ? ServiceCollectionExtensions.IgnoreSslCertificate : string.Empty;
-
-            HttpClient? httpClient = _options.Value.HttpClient;
-            httpClient ??= _httpClientFactory.CreateClient(clientName);
+            var clientName = _options.Value.HttpClientName ?? ((route?.DangerousAcceptAnyServerCertificateValidator ?? false) ? ServiceCollectionExtensions.IgnoreSslCertificate : string.Empty);
+            var httpClient = _httpClientFactory.CreateClient(clientName);
 
             SetHttpVersion(httpClient, route);
             AddHeaders(httpClient);

--- a/src/MMLib.SwaggerForOcelot/Repositories/DownstreamSwaggerDocsRepository.cs
+++ b/src/MMLib.SwaggerForOcelot/Repositories/DownstreamSwaggerDocsRepository.cs
@@ -44,7 +44,9 @@ namespace MMLib.SwaggerForOcelot.Repositories
         {
             string url = await GetUrlAsync(route, endPoint, docsVersion);
             var clientName = (route?.DangerousAcceptAnyServerCertificateValidator ?? false) ? ServiceCollectionExtensions.IgnoreSslCertificate : string.Empty;
-            HttpClient httpClient = _httpClientFactory.CreateClient(clientName);
+
+            HttpClient? httpClient = _options.Value.HttpClient;
+            httpClient ??= _httpClientFactory.CreateClient(clientName);
 
             SetHttpVersion(httpClient, route);
             AddHeaders(httpClient);


### PR DESCRIPTION
In a situation personally in which I need to directly modify the HttpClient being used in this library. So I added the ability to pass in an HttpClient to the UI options, which is used for the lifetime of the application.