### PR TITLE
NullReferenceException when "servers" field in specification is present but does not contain any elements.

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -127,7 +127,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
         {
             // NOTE: Only supporting one server for now.
             string downstreamBasePath = "";
-            if (openApi.ContainsKey(OpenApiProperties.Servers) && !endPointOptions.TakeServersFromDownstreamService)
+            if (openApi.GetValue(OpenApiProperties.Servers)?.Any() == true && !endPointOptions.TakeServersFromDownstreamService)
             {
                 string firstServerUrl = openApi.GetValue(OpenApiProperties.Servers).First.Value<string>(OpenApiProperties.Url);
                 var downstreamUrl = new Uri(firstServerUrl, UriKind.RelativeOrAbsolute);


### PR DESCRIPTION
I faced this issue when integrating NestJS autogenerated specification into the Gateway running your library. 
When accessing that documentation, the "servers" array is present but it does not contain any elements. 
This causes the application to throw a NullReferenceException while parsing it.

That issue can be suppressed by switching "TransformByOcelotConfig" flag to "true" in the Ocelot configuration file. But then it's impossible to use downstream mapping, which is crucial in my case. 

Attaching a screenshot of a problem and creating a PR with the solution below.

![image](https://github.com/Burgyn/MMLib.SwaggerForOcelot/assets/35352131/49edb128-cd9d-441a-ac83-ae47f4789731)
![image](https://github.com/Burgyn/MMLib.SwaggerForOcelot/assets/35352131/b9947fe2-c701-46d0-a767-87b3893f9df2)

Call stack trace from browser network page:

System.NullReferenceException: Object reference not set to an instance of an object.
   at MMLib.SwaggerForOcelot.Transformation.SwaggerJsonTransformer.TransformOpenApi(JObject openApi, IEnumerable1 routes, String serverOverride, SwaggerEndPointOptions endPointOptions) in C:\REDACTED\ABC\MMLib.SwaggerForOcelot\Transformation\SwaggerJsonTransformer.cs:line 132
   at MMLib.SwaggerForOcelot.Transformation.SwaggerJsonTransformer.TransformSwaggerOrOpenApi(String swaggerJson, IEnumerable`1 routes, String serverOverride, SwaggerEndPointOptions endPointOptions) in C:\REDACTED\ABC\MMLib.SwaggerForOcelot\Transformation\SwaggerJsonTransformer.cs:line 66
   at MMLib.SwaggerForOcelot.Transformation.SwaggerJsonTransformer.Transform(String swaggerJson, IEnumerable1 routes, String serverOverride, SwaggerEndPointOptions endPointOptions) in C:\REDACTED\ABC\MMLib.SwaggerForOcelot\Transformation\SwaggerJsonTransformer.cs:line 39
   at MMLib.SwaggerForOcelot.Middleware.SwaggerForOcelotMiddleware.Invoke(HttpContext context, ISwaggerEndPointProvider swaggerEndPointRepository, IDownstreamSwaggerDocsRepository downstreamSwaggerDocs) in C:\REDACTED\ABC\MMLib.SwaggerForOcelot\Middleware\SwaggerForOcelotMiddleware.cs:line 97
   at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.InvokeCore(HttpContext context, PathString matchedPath, PathString remainingPath)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)


