### PR TITLE
fix: #282 fix .NET7-Ocelot19.* and .NET8-Ocelot20.* bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core if needed
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version:  7.0.x
+        dotnet-version:  8.0.x
     - name: Build
       run: dotnet build ./MMLib.SwaggerForOcelot.sln --configuration Release
     - name: Test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup .NET Core if needed
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version:  7.0.x
+        dotnet-version:  8.0.x
     - name: Build
       run: dotnet build ./MMLib.SwaggerForOcelot.sln --configuration Release
     - name: Test

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <Version>7.0.1</Version>
         <Authors>Milan Martiniak</Authors>
         <Company>MMLib</Company>
@@ -17,22 +16,27 @@
         <LangVersion>preview</LangVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
-
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
         <DocumentationFile>bin\Release\MMLib.SwaggerForOcelot.xml</DocumentationFile>
         <OutputPath>bin\Release</OutputPath>
     </PropertyGroup>
-
     <ItemGroup>
         <None Include="icon.png" Pack="true" PackagePath="" />
     </ItemGroup>
-
     <ItemGroup>
         <PackageReference Include="Kros.Utils" Version="2.1.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-        <PackageReference Include="Ocelot" Version="19.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="Ocelot" Version="18.*" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+        <PackageReference Include="Ocelot" Version="19.*" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Ocelot" Version="20.*" />
     </ItemGroup>
     <ItemGroup>
         <None Include="../../README.md" Pack="true" PackagePath="\" />

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
@@ -93,8 +93,11 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
             {
                 throw new InvalidOperationException(GetErrorMessage(endPoint));
             }
-
+#if NET6_0
             ServiceHostAndPort service = (await serviceProvider.Data.Get()).FirstOrDefault()?.HostAndPort;
+#else
+            ServiceHostAndPort service = (await serviceProvider.Data.GetAsync()).FirstOrDefault()?.HostAndPort;
+#endif
 
             if (service is null)
             {

--- a/tests/MMLib.SwaggerForOcelot.BenchmarkTests/MMLib.SwaggerForOcelot.BenchmarkTests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.BenchmarkTests/MMLib.SwaggerForOcelot.BenchmarkTests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <PublishSingleFile>true</PublishSingleFile>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
   <ItemGroup>

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -1,8 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Properties\**" />
+    <EmbeddedResource Remove="Properties\**" />
+    <None Remove="Properties\**" />
+  </ItemGroup>
   <ItemGroup>
     <None Remove="Resources\AggregatesOpenApiResource.json" />
     <None Remove="Tests\BasicConfigurationWithSchemaInHostOverride.json" />
@@ -69,8 +74,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MMLib.SwaggerForOcelot\MMLib.SwaggerForOcelot.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/tests/MMLib.SwaggerForOcelot.Tests/ServiceDiscovery/SwaggerServiceDiscoveryProviderShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/ServiceDiscovery/SwaggerServiceDiscoveryProviderShould.cs
@@ -108,7 +108,7 @@ namespace MMLib.SwaggerForOcelot.Tests.ServiceDiscovery
             options.CurrentValue.Returns(new FileConfiguration());
 
             IServiceDiscoveryProvider serviceProvider = Substitute.For<IServiceDiscoveryProvider>();
-            serviceProvider.Get().Returns(new List<Service>() { service });
+            serviceProvider.GetAsync().Returns(new List<Service>() { service });
             var response = new OkResponse<IServiceDiscoveryProvider>(serviceProvider);
 
             serviceDiscovery.Get(Arg.Any<ServiceProviderConfiguration>(), Arg.Any<DownstreamRoute>()).Returns(response);


### PR DESCRIPTION
#282 An exception A occurred when using the new version of Ocelot[19.*|20.*].
```
Method not found: 'System.Threading.Tasks.Task`1<System.Collections.Generic.List`1<Ocelot.Values.Service>> Ocelot.ServiceDiscovery.Providers.IServiceDiscoveryProvider.Get()'.
```