### PR TITLE
Respect API version when building URL to downstream swagger.json

### DIFF
--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerService.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerService.cs
@@ -13,6 +13,6 @@
         /// <summary>
         /// Gets or sets the path.
         /// </summary>
-        public string Path { get; set; } = "/swagger/v1/swagger.json";
+        public string Path { get; set; }
     }
 }

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Kros.Extensions;
+﻿using Kros.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using MMLib.SwaggerForOcelot.Configuration;
@@ -13,6 +10,9 @@ using Ocelot.ServiceDiscovery;
 using Ocelot.ServiceDiscovery.Providers;
 using Ocelot.Values;
 using Swashbuckle.AspNetCore.Swagger;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace MMLib.SwaggerForOcelot.ServiceDiscovery
 {
@@ -109,6 +109,11 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
             var builder = new UriBuilder(GetScheme(service, route), service.DownstreamHost, service.DownstreamPort)
             {
                 Path = endPoint.Service.Path
+            };
+            if (builder.Path.IsNullOrEmpty())
+            {
+                string version = endPoint.Version.IsNullOrEmpty() ? "v1" : endPoint.Version;
+                builder.Path = $"/swagger/{version}/swagger.json";
             };
 
             return builder.Uri;

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
@@ -106,15 +106,16 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
                 throw new InvalidOperationException(GetErrorMessage(endPoint));
             }
 
-            var builder = new UriBuilder(GetScheme(service, route), service.DownstreamHost, service.DownstreamPort)
-            {
-                Path = endPoint.Service.Path
-            };
-            if (builder.Path.IsNullOrEmpty())
+            var builder = new UriBuilder(GetScheme(service, route), service.DownstreamHost, service.DownstreamPort);
+            if (endPoint.Service.Path.IsNullOrEmpty())
             {
                 string version = endPoint.Version.IsNullOrEmpty() ? "v1" : endPoint.Version;
                 builder.Path = $"/swagger/{version}/swagger.json";
-            };
+            }
+            else
+            {
+                builder.Path = endPoint.Service.Path;
+            }
 
             return builder.Uri;
         }

--- a/tests/MMLib.SwaggerForOcelot.Tests/ServiceDiscovery/SwaggerServiceDiscoveryProviderShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/ServiceDiscovery/SwaggerServiceDiscoveryProviderShould.cs
@@ -50,6 +50,22 @@ namespace MMLib.SwaggerForOcelot.Tests.ServiceDiscovery
         }
 
         [Fact]
+        public async Task RespectApiVersionWhenUriIsNotExplicitlySet()
+        {
+            SwaggerServiceDiscoveryProvider provider = CreateProvider(CreateService("Projects", "localhost", 5000));
+
+            Uri uri = await provider.GetSwaggerUriAsync(
+                new SwaggerEndPointConfig()
+                {
+                    Version = "1.0",
+                    Service = new SwaggerService() { Name = "Projects" }
+                },
+                new Configuration.RouteOptions());
+
+            uri.AbsoluteUri.Should().Be("http://localhost:5000/swagger/1.0/swagger.json");
+        }
+
+        [Fact]
         public async Task ReturnUriFromServiceDiscoveryWhenRouteDoesntExist()
         {
             SwaggerServiceDiscoveryProvider provider = CreateProvider(CreateService("Projects", "localhost", 5000));


### PR DESCRIPTION
Fixes #300 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved URI building logic to handle endpoint paths and API versions dynamically.

- **Tests**
  - Added new test to validate Swagger URI generation with specific API version when not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->