### PR TITLE
Possible fix for error when swagger fails to load when there are multiple catch all routes

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -312,8 +312,6 @@ namespace MMLib.SwaggerForOcelot.Transformation
                     .Skip(1)
                     .ForEach(r => routes.Remove(r));
             }
-
-
         }
 
         private static void AddHost(JObject swagger, string swaggerHost)

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -13,6 +13,8 @@
     <None Remove="Resources\DifferentOcelotRoutesForOneDownstream.json" />
     <None Remove="Resources\DifferentOcelotRoutesForOneDownstreamTransformed.json" />
     <None Remove="Tests\BasicConfigurationWithSchemaInHostOverride.json" />
+    <EmbeddedResource Include="Resources\DifferentOcelotRoutesForOneDownstreamWithCatchAll.json" />
+    <EmbeddedResource Include="Resources\DifferentOcelotRoutesForOneDownstreamTransformedWithCatchAll.json" />
     <None Remove="Tests\Issue_128.json" />
     <None Remove="Tests\Issue_135.json" />
     <None Remove="Tests\Issue_149.json" />
@@ -26,6 +28,8 @@
     <EmbeddedResource Include="Resources\DifferentOcelotRoutesForOneDownstreamTransformed.json" />
     <EmbeddedResource Include="Resources\OpenApiWithVersionPlaceholderBase.json" />
     <EmbeddedResource Include="Resources\OpenApiWithVersionPlaceholderBaseTransformed.json" />
+    <EmbeddedResource Include="Resources\DifferentOcelotRoutesForOneDownstreamWithCatchAll.json" />
+    <EmbeddedResource Include="Resources\DifferentOcelotRoutesForOneDownstreamTransformedWithCatchAll.json" />
     <EmbeddedResource Include="Resources\OpenApiBase.json" />
     <EmbeddedResource Include="Resources\OpenApiBaseTransformed.json" />
     <EmbeddedResource Include="Tests\BasicConfigurationWithSchemaInHostOverride.json" />

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -13,8 +13,8 @@
     <None Remove="Resources\DifferentOcelotRoutesForOneDownstream.json" />
     <None Remove="Resources\DifferentOcelotRoutesForOneDownstreamTransformed.json" />
     <None Remove="Tests\BasicConfigurationWithSchemaInHostOverride.json" />
-    <EmbeddedResource Include="Resources\DifferentOcelotRoutesForOneDownstreamWithCatchAll.json" />
-    <EmbeddedResource Include="Resources\DifferentOcelotRoutesForOneDownstreamTransformedWithCatchAll.json" />
+    <None Remove="Resources\DifferentOcelotRoutesForOneDownstreamWithCatchAll.json" />
+    <None Remove="Resources\DifferentOcelotRoutesForOneDownstreamTransformedWithCatchAll.json" />
     <None Remove="Tests\Issue_128.json" />
     <None Remove="Tests\Issue_135.json" />
     <None Remove="Tests\Issue_149.json" />

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/DifferentOcelotRoutesForOneDownstreamTransformedWithCatchAll.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/DifferentOcelotRoutesForOneDownstreamTransformedWithCatchAll.json
@@ -1,0 +1,30 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "WebApplication1",
+      "version": "1.0"
+    },
+    "paths": {
+      "/get/ocelot/config/test": {
+        "get": {
+          "tags": [
+            "WebApplication1"
+          ],
+          "operationId": "testGet",
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {}
+  }

--- a/tests/MMLib.SwaggerForOcelot.Tests/Resources/DifferentOcelotRoutesForOneDownstreamWithCatchAll.json
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Resources/DifferentOcelotRoutesForOneDownstreamWithCatchAll.json
@@ -1,0 +1,48 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "WebApplication1",
+      "version": "1.0"
+    },
+    "paths": {
+      "/api/test": {
+        "get": {
+          "tags": [
+            "WebApplication1"
+          ],
+          "operationId": "testGet",
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "WebApplication1"
+          ],
+          "operationId": "testPost",
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {}
+  }


### PR DESCRIPTION
if there are multiple catchAll routes with different paths (might be redundant)

for example downstream has single route 

```
GET: /api/test
```

but in ocelot has 2 matching upstream paths 
```
GET: /get/ocelot/config/{everything}
GET: /get/ocelot/config/**test**/{everything}
```


currently our application gets an error message thrown " Can not add property get to Newtonsoft.Json.Linq.JObject. Property with the same name already exists on object."

in SwaggerJsonTransformer.cs function "SwaggerJsonTransformer.cs" replaced `route.UpstreamPath` with "ConvertDownstreamPathToUpstreamPath" that's acatually used to generater Swagger doc Json properties names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved handling of route transformations by enhancing the method responsible for removing redundant routes.
	- Added two new OpenAPI specifications that define endpoints for the API under the "WebApplication1".

- **Bug Fixes**
	- Updated logic aims to prevent exceptions during swagger document generation by ensuring accurate path comparisons.

- **Tests**
	- Introduced new test method to validate the transformation of Ocelot routes for specific downstream paths, enhancing test coverage for middleware functionality.
	- Expanded test suite with additional JSON resource configurations for Ocelot routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->