### PR TITLE
Fix missing URI scheme in Swagger when using PollConsul service discovery

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -69,7 +69,8 @@ namespace MMLib.SwaggerForOcelot.Middleware
             ISwaggerEndPointProvider swaggerEndPointRepository,
             IDownstreamSwaggerDocsRepository downstreamSwaggerDocs)
         {
-            (string version, SwaggerEndPointOptions endPoint) = GetEndPoint(context.Request.Path, swaggerEndPointRepository);
+            (string version, SwaggerEndPointOptions endPoint) =
+                GetEndPoint(context.Request.Path, swaggerEndPointRepository);
 
             if (_downstreamInterceptor is not null &&
                 !_downstreamInterceptor.DoDownstreamSwaggerEndpoint(context, version, endPoint))
@@ -92,7 +93,8 @@ namespace MMLib.SwaggerForOcelot.Middleware
             RouteOptions route = routeOptions.FirstOrDefault(r => r.SwaggerKey == endPoint.Key);
 
             string content = await downstreamSwaggerDocs.GetSwaggerJsonAsync(route, endPoint, version);
-            if (SwaggerServiceDiscoveryProvider.ServiceProviderType != "Consul")
+            if (SwaggerServiceDiscoveryProvider.ServiceProviderType != "Consul" &&
+                SwaggerServiceDiscoveryProvider.ServiceProviderType != "PollConsul")
             {
                 if (endPoint.TransformByOcelotConfig)
                 {
@@ -125,7 +127,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
             if (string.IsNullOrWhiteSpace(_options.ServerOcelot))
             {
                 serverName = endPoint.HostOverride
-                    ?? $"{context.Request.Scheme}://{context.Request.Host.Value.RemoveSlashFromEnd()}";
+                             ?? $"{context.Request.Scheme}://{context.Request.Host.Value.RemoveSlashFromEnd()}";
             }
             else
             {
@@ -137,7 +139,8 @@ namespace MMLib.SwaggerForOcelot.Middleware
 
         private async Task<string> ReconfigureUpstreamSwagger(HttpContext context, string swaggerJson)
         {
-            if (_options.ReConfigureUpstreamSwaggerJson is not null && _options.ReConfigureUpstreamSwaggerJsonAsync is not null)
+            if (_options.ReConfigureUpstreamSwaggerJson is not null &&
+                _options.ReConfigureUpstreamSwaggerJsonAsync is not null)
             {
                 throw new Exception(
                     "Both ReConfigureUpstreamSwaggerJson and ReConfigureUpstreamSwaggerJsonAsync cannot have a value. Only use one method.");

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
@@ -108,6 +108,9 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
 
             var builder = new UriBuilder(GetScheme(service, route), service.DownstreamHost, service.DownstreamPort);
             if (builder.Scheme.IsNullOrEmpty())
+            {
+                builder.Scheme = conf?.Scheme ?? "http";
+            }
                 builder.Scheme = conf?.Scheme ?? "http";
 
             if (endPoint.Service.Path.IsNullOrEmpty())

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/SwaggerServiceDiscoveryProvider.cs
@@ -107,6 +107,9 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
             }
 
             var builder = new UriBuilder(GetScheme(service, route), service.DownstreamHost, service.DownstreamPort);
+            if (builder.Scheme.IsNullOrEmpty())
+                builder.Scheme = conf?.Scheme ?? "http";
+
             if (endPoint.Service.Path.IsNullOrEmpty())
             {
                 string version = endPoint.Version.IsNullOrEmpty() ? "v1" : endPoint.Version;
@@ -122,19 +125,20 @@ namespace MMLib.SwaggerForOcelot.ServiceDiscovery
 
         private string GetScheme(ServiceHostAndPort service, RouteOptions route)
             => (route is not null && !route.DownstreamScheme.IsNullOrEmpty())
-            ? route.DownstreamScheme
-            : !service.Scheme.IsNullOrEmpty()
-            ? service.Scheme
-            : service.DownstreamPort
-            switch
-            {
-                443 => Uri.UriSchemeHttps,
-                80 => Uri.UriSchemeHttp,
-                _ => string.Empty,
-            };
+                ? route.DownstreamScheme
+                : !service.Scheme.IsNullOrEmpty()
+                    ? service.Scheme
+                    : service.DownstreamPort
+                        switch
+                        {
+                            443 => Uri.UriSchemeHttps,
+                            80 => Uri.UriSchemeHttp,
+                            _ => string.Empty,
+                        };
 
         public static string? ServiceProviderType { get; set; }
 
-        private static string GetErrorMessage(SwaggerEndPointConfig endPoint) => $"Service with swagger documentation '{endPoint.Service.Name}' cann't be discovered";
+        private static string GetErrorMessage(SwaggerEndPointConfig endPoint) =>
+            $"Service with swagger documentation '{endPoint.Service.Name}' cann't be discovered";
     }
 }


### PR DESCRIPTION
This PR addresses an issue where the scheme is missing from the Swagger URI when using the PollConsul service discovery provider. 

Changes:
- Updated `SwaggerServiceDiscoveryProvider.GetSwaggerUri(...)` to set the scheme if missing.
- Added additional condition to avoid clearing Swagger content when the `ServiceProviderType` is `PollConsul`.

This fixes issue #307 .


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a null or empty check for the `Scheme` property in the Swagger URI builder, improving configuration handling.
  
- **Improvements**
	- Enhanced readability of the codebase through formatting adjustments in several methods.
  
- **Bug Fixes**
	- Ensured default scheme is applied when the `Scheme` property is null or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->