### PR TITLE
Add service name prefixing logic to Swagger paths in SwaggerForOcelotMiddleware

### DIFF
--- a/src/MMLib.SwaggerForOcelot/Extensions/JsonExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/Extensions/JsonExtensions.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace MMLib.SwaggerForOcelot.Extensions;
+
+/// <summary>
+///
+/// </summary>
+public static class JsonExtensions
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <param name="swaggerJson"></param>
+    /// <returns></returns>
+    public static bool TryParse(this string swaggerJson, out JObject jObj)
+    {
+        try
+        {
+            jObj = JObject.Parse(swaggerJson);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            jObj = null;
+            return false;
+        }
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -101,6 +101,10 @@ namespace MMLib.SwaggerForOcelot.Middleware
                     content = _transformer.Transform(content, routeOptions, GetServerName(context, endPoint), endPoint);
                 }
             }
+            else
+            {
+                content = _transformer.AddServiceNamePrefixToPaths(content, endPoint, version);
+            }
 
             content = await ReconfigureUpstreamSwagger(context, content);
 

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -104,6 +104,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
             else
             {
                 content = _transformer.AddServiceNamePrefixToPaths(content, endPoint, version);
+
             }
 
             content = await ReconfigureUpstreamSwagger(context, content);

--- a/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
@@ -22,5 +22,18 @@ namespace MMLib.SwaggerForOcelot.Transformation
             IEnumerable<RouteOptions> routes,
             string serverOverride,
             SwaggerEndPointOptions endPointOptions);
+
+        /// <summary>
+        /// Modifies the paths in a given Swagger JSON by adding a specified service name as a prefix to each path.
+        /// If the "paths" section is missing or null, the method returns the original Swagger JSON without modifications.
+        /// </summary>
+        /// <param name="swaggerJson">The original Swagger JSON as a string.</param>
+        /// <param name="serviceName">The service name to be prefixed to each path in the Swagger JSON.</param>
+        /// <param name="version"></param>
+        /// <returns>
+        /// A modified Swagger JSON string where each path in the "paths" section is prefixed with the provided service name.
+        /// If the "paths" section does not exist or is null, the original Swagger JSON is returned.
+        /// </returns>
+        string AddServiceNamePrefixToPaths(string swaggerJson, SwaggerEndPointOptions serviceName, string version);
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.Consul.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.Consul.cs
@@ -1,4 +1,5 @@
 using MMLib.SwaggerForOcelot.Configuration;
+using MMLib.SwaggerForOcelot.Extensions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -33,7 +34,9 @@ public partial class SwaggerJsonTransformer
         if (string.IsNullOrEmpty(serviceName))
             return swaggerJson;
 
-        var swaggerObj = JObject.Parse(swaggerJson);
+        if (!swaggerJson.TryParse(out var swaggerObj))
+            return swaggerJson;
+
         if (!swaggerObj.TryGetValue(OpenApiProperties.Paths, out var swaggerPaths))
             return swaggerJson;
 

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.Consul.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.Consul.cs
@@ -1,0 +1,40 @@
+using MMLib.SwaggerForOcelot.Configuration;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace MMLib.SwaggerForOcelot.Transformation;
+
+public partial class SwaggerJsonTransformer
+{
+    public string AddServiceNamePrefixToPaths(string swaggerJson, SwaggerEndPointOptions endPoint, string version)
+    {
+        SwaggerEndPointConfig config =
+            string.IsNullOrEmpty(version)
+                ? endPoint.Config.FirstOrDefault()
+                : endPoint.Config.FirstOrDefault(x => x.Version == version);
+
+        var serviceName = config?.Service?.Name;
+        if (string.IsNullOrEmpty(serviceName))
+            return swaggerJson;
+
+        var swaggerDoc = JsonSerializer.Deserialize<Dictionary<string, object>>(swaggerJson);
+
+        if (swaggerDoc != null && swaggerDoc.ContainsKey("paths"))
+        {
+            var paths = JsonSerializer.Deserialize<Dictionary<string, object>>(swaggerDoc["paths"].ToString());
+            var modifiedPaths = new Dictionary<string, object>();
+
+            foreach (var path in paths)
+            {
+                var newPath = $"/{serviceName}{path.Key}";
+                modifiedPaths[newPath] = path.Value;
+            }
+
+            swaggerDoc["paths"] = modifiedPaths;
+            return JsonSerializer.Serialize(swaggerDoc, new JsonSerializerOptions { WriteIndented = true });
+        }
+
+        return swaggerJson;
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -15,7 +15,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
     /// Class which implement transformation downstream service swagger json into upstream format
     /// </summary>
     /// <seealso cref="ISwaggerJsonTransformer" />
-    public class SwaggerJsonTransformer : ISwaggerJsonTransformer
+    public partial class SwaggerJsonTransformer : ISwaggerJsonTransformer
     {
         private readonly OcelotSwaggerGenOptions _ocelotSwaggerGenOptions;
         private readonly IMemoryCache _memoryCache;

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -494,6 +494,10 @@ namespace MMLib.SwaggerForOcelot.Tests
             {
                 return _transformedJson;
             }
+
+            public string AddServiceNamePrefixToPaths(string swaggerJson,
+                SwaggerEndPointOptions serviceName,
+                string version) => _transformedJson;
         }
     }
 }


### PR DESCRIPTION

This PR introduces a new feature in the SwaggerForOcelotMiddleware where the serviceName is prefixed to the paths in the Swagger JSON at the beginning of the request processing.

**New Method:** Added the AddServiceNamePrefixToPaths method, which modifies the paths section in the Swagger JSON by prepending the specified serviceName to each path.
**Middleware Change:** An else block was added in the SwaggerForOcelotMiddleware to invoke the AddServiceNamePrefixToPaths method and apply the prefixing logic to paths.
**Interface Modification:** Updated ISwaggerJsonTransformer to include the AddServiceNamePrefixToPaths method, enabling easy transformation of Swagger paths with a service name prefix.

**Why This Change is Needed**
The ability to prepend a service name to Swagger paths is essential for better API routing and management, particularly in microservice-based architectures like Ocelot. This change ensures that the correct service name is added to each path, improving the clarity of the API documentation and routing

```
public string AddServiceNamePrefixToPaths(string swaggerJson, SwaggerEndPointOptions endPoint, string version)
    {
        var config = string.IsNullOrEmpty(version)
            ? endPoint.Config.FirstOrDefault()
            : endPoint.Config.FirstOrDefault(x => x.Version == version);

        var serviceName = config?.Service?.Name;
        if (string.IsNullOrEmpty(serviceName))
            return swaggerJson;

        var swaggerObj = JObject.Parse(swaggerJson);
        if (!swaggerObj.TryGetValue(OpenApiProperties.Paths, out var swaggerPaths))
            return swaggerJson;

        if (swaggerPaths is not JObject pathsObj)
            return swaggerJson;

        var properties = pathsObj.Properties().ToList();
        properties.ForEach(f => SetToPathServiceName(f, pathsObj, serviceName));

        return swaggerObj.ToString();
    }

    /// <summary>
    ///
    /// </summary>
    /// <param name="jProperty"></param>
    /// <param name="pathsObj"></param>
    /// <param name="serviceName"></param>
    private void SetToPathServiceName(JProperty jProperty, JObject pathsObj, string serviceName)
    {
        jProperty.Remove();

        var path = $"/{serviceName}{jProperty.Name}";
        pathsObj.Add(path, jProperty.Value);
    }```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a method to add service name prefixes to paths in Swagger JSON, enhancing configurability.
	- Improved middleware functionality for generating Swagger documentation based on service provider types.
	- Added a new extension method for safely parsing JSON strings.

- **Bug Fixes**
	- Enhanced test coverage for middleware functionalities, ensuring correct transformation and handling of Swagger JSON.

- **Documentation**
	- Updated tests to validate new transformation capabilities and middleware behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->