### PR TITLE
Consul integration with serviceName prefix and ConsulClient library

### DIFF
--- a/MMLib.SwaggerForOcelot.sln
+++ b/MMLib.SwaggerForOcelot.sln
@@ -29,6 +29,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiGatewayWithEndpointInter
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MMLib.SwaggerForOcelot.BenchmarkTests", "tests\MMLib.SwaggerForOcelot.BenchmarkTests\MMLib.SwaggerForOcelot.BenchmarkTests.csproj", "{BFB72205-5F70-474B-BC43-6C0B71C39FFA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MMLib.ServiceDiscovery.Consul", "src\MMLib.ServiceDiscovery.Consul\MMLib.ServiceDiscovery.Consul.csproj", "{3935ABE3-B9AF-4BDB-8621-A59D49BF84ED}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ConsulAutoDiscovery", "ConsulAutoDiscovery", "{A91B5036-2064-4C83-B379-5AD8420C4A41}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsulApiGateway", "demo\ConsulAutoDiscovery\ConsulApiGateway\ConsulApiGateway.csproj", "{BC60A6E1-1844-4133-B0F4-DD26DD84E517}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoDiscoveryApi", "demo\ConsulAutoDiscovery\AutoDiscoveryApi\AutoDiscoveryApi.csproj", "{FDF51FDB-5D75-42E0-9FC1-193C222C624C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +83,18 @@ Global
 		{BFB72205-5F70-474B-BC43-6C0B71C39FFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BFB72205-5F70-474B-BC43-6C0B71C39FFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BFB72205-5F70-474B-BC43-6C0B71C39FFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3935ABE3-B9AF-4BDB-8621-A59D49BF84ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3935ABE3-B9AF-4BDB-8621-A59D49BF84ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3935ABE3-B9AF-4BDB-8621-A59D49BF84ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3935ABE3-B9AF-4BDB-8621-A59D49BF84ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC60A6E1-1844-4133-B0F4-DD26DD84E517}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC60A6E1-1844-4133-B0F4-DD26DD84E517}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC60A6E1-1844-4133-B0F4-DD26DD84E517}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC60A6E1-1844-4133-B0F4-DD26DD84E517}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDF51FDB-5D75-42E0-9FC1-193C222C624C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDF51FDB-5D75-42E0-9FC1-193C222C624C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDF51FDB-5D75-42E0-9FC1-193C222C624C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDF51FDB-5D75-42E0-9FC1-193C222C624C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +110,10 @@ Global
 		{DF18713F-3BE4-4300-BB41-D8239AAC2CA4} = {75938D16-D280-4200-A970-8D33B719D252}
 		{4CF0F59A-E155-4F68-B47B-7042E5A1CB2B} = {75938D16-D280-4200-A970-8D33B719D252}
 		{BFB72205-5F70-474B-BC43-6C0B71C39FFA} = {A9111054-B663-41BA-AE67-E6FE3E7515AF}
+		{3935ABE3-B9AF-4BDB-8621-A59D49BF84ED} = {D0CA2BCE-C362-4C5A-8AC9-319742DDCDD8}
+		{A91B5036-2064-4C83-B379-5AD8420C4A41} = {75938D16-D280-4200-A970-8D33B719D252}
+		{BC60A6E1-1844-4133-B0F4-DD26DD84E517} = {A91B5036-2064-4C83-B379-5AD8420C4A41}
+		{FDF51FDB-5D75-42E0-9FC1-193C222C624C} = {A91B5036-2064-4C83-B379-5AD8420C4A41}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AAA408E9-E738-4F2B-A6C2-B35AAADDB00F}

--- a/demo/ApiGateway/ApiGateway.csproj
+++ b/demo/ApiGateway/ApiGateway.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.8" />
     <PackageReference Include="MMLib.Ocelot.Provider.AppConfiguration" Version="2.0.0" />
-    <PackageReference Include="Ocelot" Version="19.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/demo/ApiGatewayWithEndpointInterceptor/ApiGatewayWithEndpointInterceptor.csproj
+++ b/demo/ApiGatewayWithEndpointInterceptor/ApiGatewayWithEndpointInterceptor.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ocelot" Version="19.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
+++ b/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ocelot" Version="19.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/demo/ConsulAutoDiscovery/AutoDiscoveryApi/AutoDiscoveryApi.csproj
+++ b/demo/ConsulAutoDiscovery/AutoDiscoveryApi/AutoDiscoveryApi.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\MMLib.ServiceDiscovery.Consul\MMLib.ServiceDiscovery.Consul.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/demo/ConsulAutoDiscovery/AutoDiscoveryApi/Program.cs
+++ b/demo/ConsulAutoDiscovery/AutoDiscoveryApi/Program.cs
@@ -1,0 +1,50 @@
+using MMLib.ServiceDiscovery.Consul.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.AddConsulAutoServiceDiscovery("http://localhost:8500"); //This line added
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseSwaggerForOcelotUI(); //This line added
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+    {
+        var forecast = Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                (
+                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                    Random.Shared.Next(-20, 55),
+                    summaries[Random.Shared.Next(summaries.Length)]
+                ))
+            .ToArray();
+        return forecast;
+    })
+    .WithName("GetWeatherForecast")
+    .WithOpenApi();
+
+app.Run("http://localhost:7002");
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/demo/ConsulAutoDiscovery/AutoDiscoveryApi/appsettings.Development.json
+++ b/demo/ConsulAutoDiscovery/AutoDiscoveryApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/demo/ConsulAutoDiscovery/AutoDiscoveryApi/appsettings.json
+++ b/demo/ConsulAutoDiscovery/AutoDiscoveryApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/demo/ConsulAutoDiscovery/ConsulApiGateway/ConsulApiGateway.csproj
+++ b/demo/ConsulAutoDiscovery/ConsulApiGateway/ConsulApiGateway.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\MMLib.SwaggerForOcelot\MMLib.SwaggerForOcelot.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/demo/ConsulAutoDiscovery/ConsulApiGateway/Program.cs
+++ b/demo/ConsulAutoDiscovery/ConsulApiGateway/Program.cs
@@ -1,0 +1,25 @@
+using Ocelot.DependencyInjection;
+using Ocelot.Provider.Consul;
+using Ocelot.Middleware;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddEndpointsApiExplorer();
+
+builder.Configuration
+    .SetBasePath(builder.Environment.ContentRootPath)
+    .AddJsonFile("ocelot.json", optional: false, reloadOnChange: true)
+    .AddEnvironmentVariables();
+
+builder.Services
+    .AddOcelot(builder.Configuration)
+    .AddConsul();
+
+builder.Services.AddSwaggerForOcelot(builder.Configuration);
+
+var app = builder.Build();
+
+app.UseSwaggerForOcelotUI();
+await app.UseOcelot();
+
+app.MapGet("/", () => "Hello World!").WithOpenApi();
+app.Run("http://0.0.0.0:7001");

--- a/demo/ConsulAutoDiscovery/ConsulApiGateway/appsettings.Development.json
+++ b/demo/ConsulAutoDiscovery/ConsulApiGateway/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/demo/ConsulAutoDiscovery/ConsulApiGateway/appsettings.json
+++ b/demo/ConsulAutoDiscovery/ConsulApiGateway/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/demo/ConsulAutoDiscovery/ConsulApiGateway/ocelot.json
+++ b/demo/ConsulAutoDiscovery/ConsulApiGateway/ocelot.json
@@ -1,0 +1,14 @@
+{
+  "Routes": [],
+  "SwaggerEndPoints": [],
+  "GlobalConfiguration": {
+    "ServiceDiscoveryProvider": {
+      "Scheme": "http",
+      "Host": "localhost",
+      "Port": 8500,
+      "Type": "PollConsul",
+      "PollingInterval": 100
+    }
+  }
+}
+

--- a/demo/OrderService/OrderService.csproj
+++ b/demo/OrderService/OrderService.csproj
@@ -13,5 +13,9 @@
   <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
  </ItemGroup>
 
+ <ItemGroup>
+   <ProjectReference Include="..\..\src\MMLib.ServiceDiscovery.Consul\MMLib.ServiceDiscovery.Consul.csproj" />
+ </ItemGroup>
+
 
 </Project>

--- a/src/MMLib.ServiceDiscovery.Consul/DependencyInjection/ConfigureExtensions.cs
+++ b/src/MMLib.ServiceDiscovery.Consul/DependencyInjection/ConfigureExtensions.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.SwaggerUI;
+
+namespace MMLib.ServiceDiscovery.Consul.DependencyInjection;
+
+/// <summary>
+///
+/// </summary>
+public static class ConfigureExtensions
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static IApplicationBuilder UseSwaggerForOcelotUI(this WebApplication builder)
+    {
+        builder.ConfigureConsulConnection();
+        builder.MapHealthChecks("/api/health");
+
+        return builder;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static IApplicationBuilder ConfigureConsulConnection(this IApplicationBuilder builder)
+    {
+        var consul = builder.ApplicationServices.GetService<IConsulConnectionService>();
+        consul?.Start();
+
+        return builder;
+    }
+}

--- a/src/MMLib.ServiceDiscovery.Consul/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MMLib.ServiceDiscovery.Consul/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,127 @@
+using Consul;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+
+namespace MMLib.ServiceDiscovery.Consul.DependencyInjection;
+
+/// <summary>
+///
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="services"></param>
+    /// <returns></returns>
+    public static WebApplicationBuilder AddConsulAutoServiceDiscovery(this WebApplicationBuilder builder,
+        string consulAddress)
+    {
+        builder.Configuration.ConfigureSettings(consulAddress);
+        builder.Services.RegisterServices(consulAddress);
+
+        return builder;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="configManager"></param>
+    /// <param name="consulAddress"></param>
+    /// <returns></returns>
+    public static IConfigurationBuilder ConfigureSettings(this IConfigurationBuilder configManager, string consulAddress)
+    {
+        configManager.AddJsonFile("appsettings.dev.json", true);
+        configManager.AddJsonFile("appsettings.prod.json", true);
+        configManager.AddConsul(consulAddress);
+        configManager.AddEnvironmentVariables();
+
+        return configManager;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="configurationManager"></param>
+    /// <param name="consulAddress"></param>
+    /// <returns></returns>
+    public static IConfigurationBuilder AddConsul(this IConfigurationBuilder configurationManager, string consulAddress)
+    {
+        var confManager = configurationManager.Build();
+        var address = confManager.GetValue<string>("ConsulAddress");
+        var client = new ConsulClient();
+        client.Config.Address = new Uri(address ?? consulAddress);
+
+        var projectName = Assembly.GetEntryAssembly()?.GetName().Name;
+        configurationManager.AddConsulJsonStream(client, "appsettings.json");
+        configurationManager.AddConsulJsonStream(client, $"appsettings.{projectName}.json");
+        return configurationManager;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="configurationManager"></param>
+    /// <param name="consulClient"></param>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    private static IConfigurationBuilder AddConsulJsonStream(this IConfigurationBuilder configurationManager,
+        ConsulClient consulClient, string key)
+    {
+        var res = consulClient.KV.Get(key).Result;
+        if (res.StatusCode == System.Net.HttpStatusCode.NotFound)
+            return configurationManager;
+
+        var responseBytes = res.Response.Value;
+        var stream = new MemoryStream(responseBytes);
+        configurationManager.AddJsonStream(stream);
+        return configurationManager;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="consulAddress"></param>
+    /// <returns></returns>
+    public static IServiceCollection RegisterServices(this IServiceCollection services, string consulAddress)
+    {
+        services
+            .RegisterConsulClient(consulAddress)
+            .AddHealthChecks();
+
+        services.AddSingleton<ISwaggerService, SwaggerService>();
+        services.AddSingleton<IConsulConnectionService, ConsulConnectionService>();
+        services.AddSingleton<IConsulNameCorrectorService, ConsulNameCorrectorService>();
+
+        return services;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="consulAddress"></param>
+    /// <returns></returns>
+    public static IServiceCollection RegisterConsulClient(this IServiceCollection services, string consulAddress)
+    {
+        services.AddSingleton<IConsulClient>(f => CreateConsuleClient(f, consulAddress));
+        return services;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    /// <param name="consulAddress"></param>
+    /// <returns></returns>
+    private static ConsulClient CreateConsuleClient(IServiceProvider serviceProvider, string consulAddress)
+    {
+        var configuration = serviceProvider.GetService<IConfiguration>();
+        var addr = configuration?.GetValue<string>("ConsulAddress");
+
+        return new ConsulClient(c => c.Address = new Uri(addr ?? consulAddress));
+    }
+}

--- a/src/MMLib.ServiceDiscovery.Consul/MMLib.ServiceDiscovery.Consul.csproj
+++ b/src/MMLib.ServiceDiscovery.Consul/MMLib.ServiceDiscovery.Consul.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Consul" Version="1.7.14.3" />
+      <PackageReference Include="Kros.Utils" Version="2.1.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    </ItemGroup>
+</Project>

--- a/src/MMLib.ServiceDiscovery.Consul/Services/Consul/ConsulConnectionService.cs
+++ b/src/MMLib.ServiceDiscovery.Consul/Services/Consul/ConsulConnectionService.cs
@@ -1,0 +1,213 @@
+using Consul;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+using Swashbuckle.AspNetCore.Swagger;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+
+namespace MMLib.ServiceDiscovery.Consul;
+
+public class ConsulConnectionService : IConsulConnectionService
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private IConsulClient _client;
+
+    /// <summary>
+    ///
+    /// </summary>
+    private IHostApplicationLifetime _applicationLifetime;
+
+    /// <summary>
+    ///
+    /// </summary>
+    private IServer _server;
+
+    /// <summary>
+    ///
+    /// </summary>
+    private readonly IConfiguration _configuration;
+
+    /// <summary>
+    ///
+    /// </summary>
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    ///
+    /// </summary>
+    private readonly ISwaggerService _swaggerService;
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="applicationLifetime"></param>
+    /// <param name="server"></param>
+    public ConsulConnectionService(
+        IConsulClient client,
+        IHostApplicationLifetime applicationLifetime,
+        IServer server,
+        IConfiguration configuration,
+        IServiceProvider serviceProvider, ISwaggerService swaggerService)
+    {
+        _client = client;
+        _applicationLifetime = applicationLifetime;
+        _server = server;
+        _configuration = configuration;
+        _serviceProvider = serviceProvider;
+        _swaggerService = swaggerService;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    public void Start()
+    {
+        _applicationLifetime.ApplicationStarted.Register(OnApplicationStarted);
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    private void OnApplicationStarted()
+    {
+        var regInfo = GetRegistrationInfo();
+        _client.Agent.ServiceDeregister(regInfo.ID).Wait();
+        _client.Agent.ServiceRegister(regInfo).Wait();
+
+        Console.WriteLine("Service registered on consul: " + regInfo.Name);
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    private string? GetStartedAddress()
+    {
+        var addressFeature = _server.Features.Get<IServerAddressesFeature>();
+        var address = addressFeature?.Addresses?.FirstOrDefault();
+        if (address is null)
+            return null;
+
+        if (!address.Contains("[::]") && !address.Contains("0.0.0.0"))
+            return address;
+
+        var localIp = GetLocalIPAddress();
+        address = address.Replace("[::]", localIp).Replace("0.0.0.0", localIp);
+
+        return address;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    private string GetLocalIPAddress()
+    {
+        var host = Dns.GetHostEntry(Dns.GetHostName());
+        foreach (var ip in host.AddressList)
+        {
+            if (ip.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(ip))
+                return ip.ToString();
+        }
+
+        return "localhost";
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    private AgentServiceRegistration GetRegistrationInfo()
+    {
+        var serviceName = GetAssemblyName();
+        var address = GetStartedAddress();
+        var url = new Uri(address);
+
+        var reg = new AgentServiceRegistration();
+        reg.ID = serviceName;
+        reg.Name = serviceName;
+        reg.Port = url.Port;
+        reg.Address = url.Host;
+        reg.Check = new AgentServiceCheck
+        {
+            HTTP = $"{address}/api/health",
+            Notes = "Checks /health on service",
+            Timeout = TimeSpan.FromSeconds(5),
+            Interval = TimeSpan.FromSeconds(2),
+        };
+
+        AddSwaggerVersionsToMeta(reg);
+
+        var cfgPort = _configuration.GetValue<int>("ConsulSettingsPort");
+        if (cfgPort != 0)
+            reg.Port = cfgPort;
+
+        var cfgHost = _configuration.GetValue<string>("ConsulSettingsAddress");
+        if (!cfgHost.IsNullOrEmpty())
+            reg.Address = cfgHost;
+
+        var cfgName = _configuration.GetValue<string>("ConsulSettingsName");
+        if (!cfgName.IsNullOrEmpty())
+        {
+            reg.Name = cfgName;
+            reg.ID = cfgName;
+        }
+
+        return reg;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    private string GetAssemblyName()
+    {
+        var assemblyName = Assembly.GetEntryAssembly()?.GetName()?.Name;
+        var consulNameCorrectors = _serviceProvider.GetServices<IConsulNameCorrectorService>().ToList();
+        consulNameCorrectors.ForEach(f => assemblyName = f.CorrectConsulName(assemblyName));
+
+        return assemblyName;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="reg"></param>
+    private void AddSwaggerVersionsToMeta(AgentServiceRegistration reg)
+    {
+        var swaggerDocs = _swaggerService.GetSwaggerInfo();
+
+        reg.Meta = new Dictionary<string, string>();
+        swaggerDocs.ForEach(version =>
+        {
+            reg.Meta.Add(
+                $"swagger_{version.Replace(".", string.Empty)}",
+                version);
+            Console.WriteLine(version);
+        });
+    }
+
+    /// <summary>
+    /// swagger/{documentName}/swagger.{json|yaml}
+    /// </summary>
+    /// <param name="routeTemplate"></param>
+    /// <param name="docVersion"></param>
+    /// <returns></returns>
+    private string GetSwaggerFileLink(string routeTemplate, string docVersion)
+    {
+        var urlBuilder = new StringBuilder(routeTemplate);
+        urlBuilder.Replace("{documentName}", docVersion);
+        urlBuilder.Replace("{json|yaml}", "json");
+
+        return urlBuilder.ToString();
+    }
+}

--- a/src/MMLib.ServiceDiscovery.Consul/Services/Consul/ConsulNameCorrectorService.cs
+++ b/src/MMLib.ServiceDiscovery.Consul/Services/Consul/ConsulNameCorrectorService.cs
@@ -1,0 +1,17 @@
+namespace MMLib.ServiceDiscovery.Consul;
+
+/// <summary>
+///
+/// </summary>
+public class ConsulNameCorrectorService : IConsulNameCorrectorService
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public string CorrectConsulName(string name)
+    {
+        return name?.Replace("MS.", string.Empty);
+    }
+}

--- a/src/MMLib.ServiceDiscovery.Consul/Services/Consul/IConsulConnectionService.cs
+++ b/src/MMLib.ServiceDiscovery.Consul/Services/Consul/IConsulConnectionService.cs
@@ -1,0 +1,12 @@
+namespace MMLib.ServiceDiscovery.Consul;
+
+/// <summary>
+///
+/// </summary>
+public interface IConsulConnectionService
+{
+    /// <summary>
+    ///
+    /// </summary>
+    void Start();
+}

--- a/src/MMLib.ServiceDiscovery.Consul/Services/Consul/IConsulNameCorrectorService.cs
+++ b/src/MMLib.ServiceDiscovery.Consul/Services/Consul/IConsulNameCorrectorService.cs
@@ -1,0 +1,9 @@
+namespace MMLib.ServiceDiscovery.Consul;
+
+/// <summary>
+///
+/// </summary>
+public interface IConsulNameCorrectorService
+{
+    string CorrectConsulName(string name);
+}

--- a/src/MMLib.ServiceDiscovery.Consul/Services/Swagger/ISwaggerService.cs
+++ b/src/MMLib.ServiceDiscovery.Consul/Services/Swagger/ISwaggerService.cs
@@ -1,0 +1,16 @@
+using Microsoft.OpenApi.Models;
+
+namespace MMLib.ServiceDiscovery.Consul;
+
+/// <summary>
+///
+/// </summary>
+public interface ISwaggerService
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    List<string> GetSwaggerInfo();
+
+}

--- a/src/MMLib.ServiceDiscovery.Consul/Services/Swagger/SwaggerService.cs
+++ b/src/MMLib.ServiceDiscovery.Consul/Services/Swagger/SwaggerService.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MMLib.ServiceDiscovery.Consul;
+
+/// <summary>
+///
+/// </summary>
+public class SwaggerService : ISwaggerService
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private readonly SwaggerGeneratorOptions _swaggerGeneratorOptions;
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="swaggerGeneratorOptions"></param>
+    public SwaggerService(IOptions<SwaggerGeneratorOptions> swaggerGeneratorOptions)
+    {
+        _swaggerGeneratorOptions = swaggerGeneratorOptions.Value;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    public List<string> GetSwaggerInfo()
+    {
+        return _swaggerGeneratorOptions.SwaggerDocs.Keys.ToList();
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/SwaggerEndPointOptions.cs
@@ -28,10 +28,11 @@ namespace MMLib.SwaggerForOcelot.Configuration
         /// Gets the path from key.
         /// </summary>
         public string KeyToPath => WebUtility.UrlEncode(Key);
+
         /// <summary>
         /// The swagger endpoint config collection
         /// </summary>
-        public List<SwaggerEndPointConfig> Config { get; set; }
+        public List<SwaggerEndPointConfig> Config { get; set; } = new();
 
         /// <summary>
         /// This host url is use used to overwrite the host of the upstream service.

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using Consul;
+using Microsoft.Extensions.Configuration;
 using MMLib.SwaggerForOcelot.Configuration;
 using MMLib.SwaggerForOcelot.ServiceDiscovery;
 using MMLib.SwaggerForOcelot.Transformation;
@@ -10,8 +11,16 @@ using Microsoft.OpenApi.Models;
 using MMLib.SwaggerForOcelot.Repositories;
 using MMLib.SwaggerForOcelot.Aggregates;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using MMLib.SwaggerForOcelot.ServiceDiscovery.ConsulServiceDiscoveries;
+using Ocelot.Configuration;
+using Ocelot.Configuration.Creator;
+using Ocelot.Configuration.File;
+using Swashbuckle.AspNetCore.Swagger;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
+using RouteOptions = MMLib.SwaggerForOcelot.Configuration.RouteOptions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -21,6 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class ServiceCollectionExtensions
     {
         public const string IgnoreSslCertificate = "HttpClientWithSSLUntrusted";
+
         /// <summary>
         /// Adds configuration for for <see cref="SwaggerForOcelotMiddleware"/> into <see cref="IServiceCollection"/>.
         /// </summary>
@@ -36,12 +46,15 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<SwaggerGenOptions> swaggerSetup = null)
         {
             services
+                .AddSingleton<IConsulServiceDiscovery, ConsulServiceDisvovery>()
                 .AddTransient<IRoutesDocumentationProvider, RoutesDocumentationProvider>()
                 .AddTransient<IDownstreamSwaggerDocsRepository, DownstreamSwaggerDocsRepository>()
                 .AddTransient<ISwaggerServiceDiscoveryProvider, SwaggerServiceDiscoveryProvider>()
                 .AddTransient<ISwaggerJsonTransformer, SwaggerJsonTransformer>()
                 .Configure<List<RouteOptions>>(configuration.GetSection("Routes"))
-                .Configure<List<SwaggerEndPointOptions>>(configuration.GetSection(SwaggerEndPointOptions.ConfigurationSectionName))
+                .Configure<List<SwaggerEndPointOptions>>(
+                    configuration.GetSection(SwaggerEndPointOptions.ConfigurationSectionName))
+                .AddDynamicConsulConfigs()
                 .AddHttpClient()
                 .AddMemoryCache()
                 .AddTransient<ISwaggerEndPointProvider, SwaggerEndPointProvider>();
@@ -53,7 +66,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 return new HttpClientHandler
                 {
                     ClientCertificateOptions = ClientCertificateOption.Manual,
-                    ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, certChain, policyErrors) => true
+                    ServerCertificateCustomValidationCallback =
+                        (httpRequestMessage, cert, certChain, policyErrors) => true
                 };
             });
 
@@ -67,7 +81,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (options.GenerateDocsForAggregates)
             {
-                services.Configure<List<SwaggerAggregateRoute>>(options => configuration.GetSection("Aggregates").Bind(options));
+                services.Configure<List<SwaggerAggregateRoute>>(options =>
+                    configuration.GetSection("Aggregates").Bind(options));
             }
 
             services.AddSwaggerGen(c =>
@@ -81,6 +96,83 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="services"></param>
+        public static IServiceCollection AddDynamicConsulConfigs(this IServiceCollection services)
+        {
+            var conf = GetConfig(services);
+            if (conf?.Type is not ("Consul" or "PollConsul"))
+                return services;
+
+            services.AddConsulClient(conf);
+
+            var service = services.BuildServiceProvider().GetRequiredService<IConsulServiceDiscovery>();
+            var consulServices = service.GetServicesAsync().GetAwaiter().GetResult();
+
+            services.Configure<List<SwaggerEndPointOptions>>(options =>
+            {
+                consulServices.ForEach(f => InitOptions(f, options));
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        private static ServiceProviderConfiguration GetConfig(IServiceCollection services)
+        {
+            var sb = services.BuildServiceProvider();
+            var configurationCreator = sb.GetRequiredService<IServiceProviderConfigurationCreator>();
+            var options = sb.GetRequiredService<IOptionsMonitor<FileConfiguration>>();
+
+            var conf = configurationCreator.Create(options.CurrentValue.GlobalConfiguration);
+            return conf;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="conf"></param>
+        public static void AddConsulClient(this IServiceCollection services,
+            ServiceProviderConfiguration conf)
+        {
+            var consulAddress = new Uri($"{conf.Scheme}://{conf.Host}:{conf.Port}");
+
+            services.AddSingleton<IConsulClient>(f => CreateConsuleClient(f, consulAddress));
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="serviceProvider"></param>
+        /// <param name="consulAddress"></param>
+        /// <returns></returns>
+        private static IConsulClient CreateConsuleClient(IServiceProvider serviceProvider, Uri consulAddress)
+        {
+            return new ConsulClient(c => c.Address = consulAddress);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="options"></param>
+        private static void InitOptions(SwaggerEndPointOptions obj, List<SwaggerEndPointOptions> options)
+        {
+            var optionKeys = new HashSet<string>(options.Select(s => s.Key));
+            if (optionKeys.Contains(obj.Key))
+                return;
+
+            options.Add(obj);
+            optionKeys.Add(obj.Key); // Keep HashSet in sync with the updated options
+        }
+
         private static void AddGatewayItSelfDocs(SwaggerGenOptions c, OcelotSwaggerGenOptions options)
         {
             if (options.GenerateDocsForGatewayItSelf)
@@ -89,10 +181,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 if (options.OcelotGatewayItSelfSwaggerGenOptions is not null)
                 {
-                    InvokeSwaggerGenOptionsActions(options.OcelotGatewayItSelfSwaggerGenOptions.DocumentFilterActions, c);
-                    InvokeSwaggerGenOptionsActions(options.OcelotGatewayItSelfSwaggerGenOptions.OperationFilterActions, c);
-                    InvokeSwaggerGenOptionsActions(options.OcelotGatewayItSelfSwaggerGenOptions.SecurityDefinitionActions, c);
-                    InvokeSwaggerGenOptionsActions(options.OcelotGatewayItSelfSwaggerGenOptions.SecurityRequirementActions, c);
+                    InvokeSwaggerGenOptionsActions(options.OcelotGatewayItSelfSwaggerGenOptions.DocumentFilterActions,
+                        c);
+                    InvokeSwaggerGenOptionsActions(options.OcelotGatewayItSelfSwaggerGenOptions.OperationFilterActions,
+                        c);
+                    InvokeSwaggerGenOptionsActions(
+                        options.OcelotGatewayItSelfSwaggerGenOptions.SecurityDefinitionActions, c);
+                    InvokeSwaggerGenOptionsActions(
+                        options.OcelotGatewayItSelfSwaggerGenOptions.SecurityRequirementActions, c);
                     IncludeXmlComments(options.OcelotGatewayItSelfSwaggerGenOptions.FilePathsForXmlComments, c);
                 }
             }
@@ -102,11 +198,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (options.GenerateDocsForAggregates)
             {
-                c.SwaggerDoc(OcelotSwaggerGenOptions.AggregatesKey, new OpenApiInfo
-                {
-                    Title = "Aggregates",
-                    Version = OcelotSwaggerGenOptions.AggregatesKey
-                });
+                c.SwaggerDoc(OcelotSwaggerGenOptions.AggregatesKey,
+                    new OpenApiInfo { Title = "Aggregates", Version = OcelotSwaggerGenOptions.AggregatesKey });
                 c.DocumentFilter<AggregatesDocumentFilter>();
             }
         }

--- a/src/MMLib.SwaggerForOcelot/Extensions/JsonExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/Extensions/JsonExtensions.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace MMLib.SwaggerForOcelot.Extensions;
+
+/// <summary>
+///
+/// </summary>
+public static class JsonExtensions
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <param name="swaggerJson"></param>
+    /// <returns></returns>
+    public static bool TryParse(this string swaggerJson, out JObject jObj)
+    {
+        try
+        {
+            jObj = JObject.Parse(swaggerJson);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            jObj = null;
+            return false;
+        }
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -9,7 +9,7 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/Burgyn/MMLib.SwaggerForOcelot</RepositoryUrl>
         <PackageTags>swagger;documentation;ocelot</PackageTags>
-        <PackageReleaseNotes />
+        <PackageReleaseNotes/>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Copyright>@MMLib</Copyright>
@@ -21,24 +21,34 @@
         <OutputPath>bin\Release</OutputPath>
     </PropertyGroup>
     <ItemGroup>
-        <None Include="icon.png" Pack="true" PackagePath="" />
+        <None Include="icon.png" Pack="true" PackagePath=""/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Kros.Utils" Version="2.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
+        <PackageReference Include="Consul" Version="1.7.14.3"/>
+        <PackageReference Include="Kros.Utils" Version="2.1.0"/>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Ocelot" Version="18.*" />
+        <PackageReference Include="Ocelot" Version="18.*"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Ocelot" Version="19.*" />
+        <PackageReference Include="Ocelot" Version="19.*"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Ocelot" Version="20.*" />
+        <PackageReference Include="Ocelot" Version="20.*"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="Ocelot.Provider.Consul" Version="18.*"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+        <PackageReference Include="Ocelot.Provider.Consul" Version="19.*"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Ocelot.Provider.Consul" Version="20.*"/>
     </ItemGroup>
     <ItemGroup>
-        <None Include="../../README.md" Pack="true" PackagePath="\" />
+        <None Include="../../README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 </Project>

--- a/src/MMLib.SwaggerForOcelot/Middleware/BuilderExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/BuilderExtensions.cs
@@ -29,7 +29,8 @@ namespace Microsoft.AspNetCore.Builder
             Action<SwaggerForOcelotUIOptions> setupAction = null,
             Action<SwaggerUIOptions> setupUiAction = null)
         {
-            SwaggerForOcelotUIOptions options = app.ApplicationServices.GetService<IOptions<SwaggerForOcelotUIOptions>>().Value;
+            SwaggerForOcelotUIOptions options =
+                app.ApplicationServices.GetService<IOptions<SwaggerForOcelotUIOptions>>().Value;
             setupAction?.Invoke(options);
             UseSwaggerForOcelot(app, options);
 
@@ -46,10 +47,12 @@ namespace Microsoft.AspNetCore.Builder
             return app;
         }
 
-        private static void ChangeDetection(IApplicationBuilder app, SwaggerUIOptions c, SwaggerForOcelotUIOptions options)
+        private static void ChangeDetection(IApplicationBuilder app, SwaggerUIOptions c,
+            SwaggerForOcelotUIOptions options)
         {
             IOptionsMonitor<List<SwaggerEndPointOptions>> endpointsChangeMonitor =
                 app.ApplicationServices.GetService<IOptionsMonitor<List<SwaggerEndPointOptions>>>();
+
             endpointsChangeMonitor.OnChange((newEndpoints) =>
             {
                 c.ConfigObject.Urls = null;
@@ -73,7 +76,8 @@ namespace Microsoft.AspNetCore.Builder
             => app.UseSwaggerForOcelotUI(setupAction);
 
         private static void UseSwaggerForOcelot(IApplicationBuilder app, SwaggerForOcelotUIOptions options)
-            => app.Map(options.PathToSwaggerGenerator, builder => builder.UseMiddleware<SwaggerForOcelotMiddleware>(options));
+            => app.Map(options.PathToSwaggerGenerator,
+                builder => builder.UseMiddleware<SwaggerForOcelotMiddleware>(options));
 
         private static void AddSwaggerEndPoints(
             SwaggerUIOptions c,
@@ -83,11 +87,11 @@ namespace Microsoft.AspNetCore.Builder
             static string GetDescription(SwaggerEndPointConfig config)
                 => config.IsGatewayItSelf ? config.Name : $"{config.Name} - {config.Version}";
 
-            if (endPoints is null || endPoints.Count == 0)
-            {
-                throw new InvalidOperationException(
-                    $"{SwaggerEndPointOptions.ConfigurationSectionName} configuration section is missing or empty.");
-            }
+            // if (endPoints is null || endPoints.Count == 0)
+            // {
+            //     throw new InvalidOperationException(
+            //         $"{SwaggerEndPointOptions.ConfigurationSectionName} configuration section is missing or empty.");
+            // }
 
             foreach (SwaggerEndPointOptions endPoint in endPoints)
             {

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -101,6 +101,10 @@ namespace MMLib.SwaggerForOcelot.Middleware
                     content = _transformer.Transform(content, routeOptions, GetServerName(context, endPoint), endPoint);
                 }
             }
+            else
+            {
+                content = _transformer.AddServiceNamePrefixToPaths(content, endPoint, version);
+            }
 
             content = await ReconfigureUpstreamSwagger(context, content);
 

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -104,7 +104,6 @@ namespace MMLib.SwaggerForOcelot.Middleware
             else
             {
                 content = _transformer.AddServiceNamePrefixToPaths(content, endPoint, version);
-
             }
 
             content = await ReconfigureUpstreamSwagger(context, content);

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -104,6 +104,7 @@ namespace MMLib.SwaggerForOcelot.Middleware
             else
             {
                 content = _transformer.AddServiceNamePrefixToPaths(content, endPoint, version);
+
             }
 
             content = await ReconfigureUpstreamSwagger(context, content);

--- a/src/MMLib.SwaggerForOcelot/Repositories/ConsulSwaggerEndpointProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/Repositories/ConsulSwaggerEndpointProvider.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Options;
+using MMLib.SwaggerForOcelot.Configuration;
+using MMLib.SwaggerForOcelot.ServiceDiscovery.ConsulServiceDiscoveries;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MMLib.SwaggerForOcelot.Repositories;
+
+/// <summary>
+///
+/// </summary>
+public class ConsulSwaggerEndpointProvider : ISwaggerEndPointProvider
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public IConsulServiceDiscovery _service { get; set; }
+
+    /// <summary>
+    ///
+    /// </summary>
+    private readonly IOptionsMonitor<List<SwaggerEndPointOptions>> _swaggerEndPointsOptions;
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="service"></param>
+    public ConsulSwaggerEndpointProvider(IConsulServiceDiscovery service,
+        IOptionsMonitor<List<SwaggerEndPointOptions>> swaggerEndPointsOptions)
+    {
+        _service = service;
+        _swaggerEndPointsOptions = swaggerEndPointsOptions;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    public IReadOnlyList<SwaggerEndPointOptions> GetAll()
+    {
+        var endpoints = _service.GetServicesAsync().GetAwaiter().GetResult();
+        if (endpoints.Count == 0)
+            endpoints = _swaggerEndPointsOptions.CurrentValue;
+
+        return endpoints;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public SwaggerEndPointOptions GetByKey(string key)
+    {
+        var endpoint = _service.GetByKeyAsync(key).GetAwaiter().GetResult();
+        if (endpoint is null)
+            endpoint = _swaggerEndPointsOptions.CurrentValue
+                .FirstOrDefault(f => f.Key == key);
+
+        return endpoint;
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/Repositories/SwaggerEndPointProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/Repositories/SwaggerEndPointProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Kros.Utils;
 using Microsoft.Extensions.Options;
 using MMLib.SwaggerForOcelot.Configuration;
+using MMLib.SwaggerForOcelot.ServiceDiscovery.ConsulServiceDiscoveries;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MMLib.SwaggerForOcelot/Repositories/SwaggerEndPointProvider.cs
+++ b/src/MMLib.SwaggerForOcelot/Repositories/SwaggerEndPointProvider.cs
@@ -1,7 +1,6 @@
 ﻿using Kros.Utils;
 using Microsoft.Extensions.Options;
 using MMLib.SwaggerForOcelot.Configuration;
-using MMLib.SwaggerForOcelot.ServiceDiscovery.ConsulServiceDiscoveries;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -57,18 +56,15 @@ namespace MMLib.SwaggerForOcelot.Repositories
         }
 
         private static void AddEndpoint(Dictionary<string, SwaggerEndPointOptions> ret, string key, string description)
-            => ret.Add($"/{key}", new SwaggerEndPointOptions()
-            {
-                Key = key,
-                TransformByOcelotConfig = false,
-                Config = new List<SwaggerEndPointConfig>() {
-                    new SwaggerEndPointConfig()
+            => ret.Add($"/{key}",
+                new SwaggerEndPointOptions()
+                {
+                    Key = key,
+                    TransformByOcelotConfig = false,
+                    Config = new List<SwaggerEndPointConfig>()
                     {
-                        Name = description,
-                        Version = key,
-                        Url = ""
+                        new SwaggerEndPointConfig() { Name = description, Version = key, Url = "" }
                     }
-                }
-            });
+                });
     }
 }

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/ConsulServiceDiscoveries/ConsulServiceDisvovery.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/ConsulServiceDiscoveries/ConsulServiceDisvovery.cs
@@ -1,0 +1,50 @@
+using Consul;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MMLib.SwaggerForOcelot.Configuration;
+using Ocelot.Configuration.Creator;
+using Ocelot.Configuration.File;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MMLib.SwaggerForOcelot.ServiceDiscovery.ConsulServiceDiscoveries;
+
+public class ConsulServiceDisvovery : IConsulServiceDiscovery
+{
+    private readonly IConsulClient _consulClient;
+
+    public ConsulServiceDisvovery(IServiceProvider serviceProvider)
+    {
+        _consulClient = serviceProvider.GetRequiredService<IConsulClient>();
+    }
+
+    public async Task<List<SwaggerEndPointOptions>> GetServicesAsync()
+    {
+        var services = await _consulClient.Agent.Services();
+        var serviceNames = new List<SwaggerEndPointOptions>();
+
+        serviceNames = services.Response.Select(service => new SwaggerEndPointOptions
+        {
+            Key = service.Key,
+            TransformByOcelotConfig = false,
+            Config = new List<SwaggerEndPointConfig>
+            {
+                new()
+                {
+                    Name = $"{service.Value.Service} API",
+                    Version = "v1", //Need to make general logic
+                    Service = new SwaggerService
+                    {
+                        Name = service.Value.Service,
+                        Path = $"/swagger/v1/swagger.json" //set version
+                    }
+                }
+            }
+        }).ToList();
+
+
+        return serviceNames;
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/ConsulServiceDiscoveries/IConsulServiceDiscovery.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/ConsulServiceDiscoveries/IConsulServiceDiscovery.cs
@@ -1,0 +1,10 @@
+using MMLib.SwaggerForOcelot.Configuration;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MMLib.SwaggerForOcelot.ServiceDiscovery.ConsulServiceDiscoveries;
+
+public interface IConsulServiceDiscovery
+{
+    Task<List<SwaggerEndPointOptions>> GetServicesAsync();
+}

--- a/src/MMLib.SwaggerForOcelot/ServiceDiscovery/ConsulServiceDiscoveries/IConsulServiceDiscovery.cs
+++ b/src/MMLib.SwaggerForOcelot/ServiceDiscovery/ConsulServiceDiscoveries/IConsulServiceDiscovery.cs
@@ -4,7 +4,21 @@ using System.Threading.Tasks;
 
 namespace MMLib.SwaggerForOcelot.ServiceDiscovery.ConsulServiceDiscoveries;
 
+/// <summary>
+///
+/// </summary>
 public interface IConsulServiceDiscovery
 {
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
     Task<List<SwaggerEndPointOptions>> GetServicesAsync();
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    Task<SwaggerEndPointOptions> GetByKeyAsync(string key);
 }

--- a/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/ISwaggerJsonTransformer.cs
@@ -22,5 +22,18 @@ namespace MMLib.SwaggerForOcelot.Transformation
             IEnumerable<RouteOptions> routes,
             string serverOverride,
             SwaggerEndPointOptions endPointOptions);
+
+        /// <summary>
+        /// Modifies the paths in a given Swagger JSON by adding a specified service name as a prefix to each path.
+        /// If the "paths" section is missing or null, the method returns the original Swagger JSON without modifications.
+        /// </summary>
+        /// <param name="swaggerJson">The original Swagger JSON as a string.</param>
+        /// <param name="serviceName">The service name to be prefixed to each path in the Swagger JSON.</param>
+        /// <param name="version"></param>
+        /// <returns>
+        /// A modified Swagger JSON string where each path in the "paths" section is prefixed with the provided service name.
+        /// If the "paths" section does not exist or is null, the original Swagger JSON is returned.
+        /// </returns>
+        string AddServiceNamePrefixToPaths(string swaggerJson, SwaggerEndPointOptions serviceName, string version);
     }
 }

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.Consul.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.Consul.cs
@@ -1,4 +1,5 @@
 using MMLib.SwaggerForOcelot.Configuration;
+using MMLib.SwaggerForOcelot.Extensions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -33,7 +34,9 @@ public partial class SwaggerJsonTransformer
         if (string.IsNullOrEmpty(serviceName))
             return swaggerJson;
 
-        var swaggerObj = JObject.Parse(swaggerJson);
+        if (!swaggerJson.TryParse(out var swaggerObj))
+            return swaggerJson;
+
         if (!swaggerObj.TryGetValue(OpenApiProperties.Paths, out var swaggerPaths))
             return swaggerJson;
 

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.Consul.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.Consul.cs
@@ -1,0 +1,40 @@
+using MMLib.SwaggerForOcelot.Configuration;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace MMLib.SwaggerForOcelot.Transformation;
+
+public partial class SwaggerJsonTransformer
+{
+    public string AddServiceNamePrefixToPaths(string swaggerJson, SwaggerEndPointOptions endPoint, string version)
+    {
+        SwaggerEndPointConfig config =
+            string.IsNullOrEmpty(version)
+                ? endPoint.Config.FirstOrDefault()
+                : endPoint.Config.FirstOrDefault(x => x.Version == version);
+
+        var serviceName = config?.Service?.Name;
+        if (string.IsNullOrEmpty(serviceName))
+            return swaggerJson;
+
+        var swaggerDoc = JsonSerializer.Deserialize<Dictionary<string, object>>(swaggerJson);
+
+        if (swaggerDoc != null && swaggerDoc.ContainsKey("paths"))
+        {
+            var paths = JsonSerializer.Deserialize<Dictionary<string, object>>(swaggerDoc["paths"].ToString());
+            var modifiedPaths = new Dictionary<string, object>();
+
+            foreach (var path in paths)
+            {
+                var newPath = $"/{serviceName}{path.Key}";
+                modifiedPaths[newPath] = path.Value;
+            }
+
+            swaggerDoc["paths"] = modifiedPaths;
+            return JsonSerializer.Serialize(swaggerDoc, new JsonSerializerOptions { WriteIndented = true });
+        }
+
+        return swaggerJson;
+    }
+}

--- a/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
+++ b/src/MMLib.SwaggerForOcelot/Transformation/SwaggerJsonTransformer.cs
@@ -15,7 +15,7 @@ namespace MMLib.SwaggerForOcelot.Transformation
     /// Class which implement transformation downstream service swagger json into upstream format
     /// </summary>
     /// <seealso cref="ISwaggerJsonTransformer" />
-    public class SwaggerJsonTransformer : ISwaggerJsonTransformer
+    public partial class SwaggerJsonTransformer : ISwaggerJsonTransformer
     {
         private readonly OcelotSwaggerGenOptions _ocelotSwaggerGenOptions;
         private readonly IMemoryCache _memoryCache;

--- a/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/SwaggerForOcelotMiddlewareShould.cs
@@ -494,6 +494,10 @@ namespace MMLib.SwaggerForOcelot.Tests
             {
                 return _transformedJson;
             }
+
+            public string AddServiceNamePrefixToPaths(string swaggerJson,
+                SwaggerEndPointOptions serviceName,
+                string version) => _transformedJson;
         }
     }
 }


### PR DESCRIPTION
### Overview:
This PR introduces several key updates related to Consul service discovery and Swagger endpoint handling within the Ocelot setup.

### Changes:

1. **Added `MMLib.ServiceDiscovery.Consul`:**
   - Introduced a new project for Consul service auto-discovery. 
   - This enables clients who don't define Swagger endpoints in their `ocelot.json` to use Consul for discovery.

2. **Updated `MMLib.SwaggerForOcelot` in `ServiceCollectionExtensions`:**
   - Modified the `AddSwaggerForOcelot` method to include conditional handling for Consul.
   - Now checks if Consul is being used, to configure Swagger appropriately.

3. **Introduced `ConsulSwaggerEndpointProvider`:**
   - This new class retrieves Swagger endpoints from Consul for clients using Consul or PollConsul as the discovery type.
   - It ensures proper Swagger integration with Consul-managed services.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced multiple new projects for enhanced service discovery and API management, including `MMLib.ServiceDiscovery.Consul`, `ConsulAutoDiscovery`, `ConsulApiGateway`, and `AutoDiscoveryApi`.
	- Added Swagger support for API documentation in new projects.
	- Implemented a weather forecast endpoint in the `AutoDiscoveryApi`.

- **Bug Fixes**
	- Removed outdated `Ocelot` package references from several projects to streamline dependencies.

- **Documentation**
	- New configuration files for development and production settings in `AutoDiscoveryApi` and `ConsulApiGateway`.

- **Chores**
	- Restructured Swagger UI configuration in the `OrderService` for better organization and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->