### PR TITLE
Update to .net 10 and Swashbuckle 10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core if needed
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version:  8.0.x
+        dotnet-version:  10.0.x
     - name: Build
       run: dotnet build ./MMLib.SwaggerForOcelot.sln --configuration Release
     - name: Test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core if needed
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version:  10.0.x
+        dotnet-version: 10.0.x
     - name: Build
       run: dotnet build ./MMLib.SwaggerForOcelot.sln --configuration Release
     - name: Test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup .NET Core if needed
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version:  10.0.x
+        dotnet-version: 10.0.x
     - name: Build
       run: dotnet build ./MMLib.SwaggerForOcelot.sln --configuration Release
     - name: Test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core if needed
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version:  8.0.x
+        dotnet-version:  10.0.x
     - name: Build
       run: dotnet build ./MMLib.SwaggerForOcelot.sln --configuration Release
     - name: Test

--- a/demo/ApiGateway/ApiGateway.csproj
+++ b/demo/ApiGateway/ApiGateway.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
-    <PackageReference Include="MMLib.Ocelot.Provider.AppConfiguration" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0" />
+    <PackageReference Include="MMLib.Ocelot.Provider.AppConfiguration" Version="4.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/ApiGateway/Startup.cs
+++ b/demo/ApiGateway/Startup.cs
@@ -1,14 +1,13 @@
-﻿using System.Collections.Generic;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
+using MMLib.Ocelot.Provider.AppConfiguration;
 using Ocelot.DependencyInjection;
 using Ocelot.Middleware;
-using Microsoft.Extensions.Hosting;
-using MMLib.Ocelot.Provider.AppConfiguration;
-using Microsoft.OpenApi.Models;
+using System.Collections.Generic;
 
 namespace ApiGateway
 {

--- a/demo/ApiGatewayWithEndpointInterceptor/ApiGatewayWithEndpointInterceptor.csproj
+++ b/demo/ApiGatewayWithEndpointInterceptor/ApiGatewayWithEndpointInterceptor.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>ApiGatewayWithEndpointSecurity</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
+++ b/demo/ApiGatewayWithPath/ApiGatewayWithPath.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/demo/ContactService/ContactService.csproj
+++ b/demo/ContactService/ContactService.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/demo/ContactService/Startup.cs
+++ b/demo/ContactService/Startup.cs
@@ -1,10 +1,9 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
 
 namespace ContactService
 {

--- a/demo/OrderService/ConfigureSwaggerOptions.cs
+++ b/demo/OrderService/ConfigureSwaggerOptions.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
+﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
 
 namespace OrderService
 {

--- a/demo/OrderService/NonBodyParameter.cs
+++ b/demo/OrderService/NonBodyParameter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using Microsoft.OpenApi;
 
 namespace OrderService
 {

--- a/demo/OrderService/OrderService.csproj
+++ b/demo/OrderService/OrderService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
  <PropertyGroup>
-  <TargetFramework>net8.0</TargetFramework>
+  <TargetFramework>net10.0</TargetFramework>
   <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   <RootNamespace>OrderService</RootNamespace>
   <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildThisFileName).xml</DocumentationFile>
@@ -10,7 +10,7 @@
  <ItemGroup>
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
   <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-  <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+  <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
  </ItemGroup>
 
 

--- a/demo/OrderService/SwaggerDefaultValues.cs
+++ b/demo/OrderService/SwaggerDefaultValues.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Linq;
 

--- a/demo/PetstoreService/PetstoreService.csproj
+++ b/demo/PetstoreService/PetstoreService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/demo/ProjectService/Program.cs
+++ b/demo/ProjectService/Program.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
+﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace ProjectService
 {

--- a/demo/ProjectService/ProjectService.csproj
+++ b/demo/ProjectService/ProjectService.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MMLib.RapidPrototyping" Version="1.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/demo/ProjectService/Startup.cs
+++ b/demo/ProjectService/Startup.cs
@@ -2,8 +2,8 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
 
 namespace ProjectService
 {

--- a/src/MMLib.SwaggerForOcelot/Aggregates/AggregateRouteDocumentationGenerator.cs
+++ b/src/MMLib.SwaggerForOcelot/Aggregates/AggregateRouteDocumentationGenerator.cs
@@ -67,7 +67,7 @@ namespace MMLib.SwaggerForOcelot.Aggregates
             OpenApiDocument openApiDocument)
         {
             Response response = CreateResponseSchema(routes, aggregateRoute, openApiDocument);
-            Dictionary<HttpMethod, OpenApiOperation> operations = CreateOperations(aggregateRoute, routes, response);
+            Dictionary<HttpMethod, OpenApiOperation> operations = CreateOperations(aggregateRoute, routes, response, openApiDocument);
 
             return new OpenApiPathItem()
             {
@@ -78,12 +78,13 @@ namespace MMLib.SwaggerForOcelot.Aggregates
         private static Dictionary<HttpMethod, OpenApiOperation> CreateOperations(
             SwaggerAggregateRoute aggregateRoute,
             IEnumerable<RouteDocs> routes,
-            Response response)
+            Response response,
+            OpenApiDocument openApiDocument)
             => new Dictionary<HttpMethod, OpenApiOperation>()
             {
                 {
                     HttpMethod.Get,
-                    CreateOperation(aggregateRoute, routes, response)
+                    CreateOperation(aggregateRoute, routes, response, openApiDocument)
                 }
             };
 
@@ -157,9 +158,10 @@ namespace MMLib.SwaggerForOcelot.Aggregates
         private static OpenApiOperation CreateOperation(
             SwaggerAggregateRoute aggregateRoute,
             IEnumerable<RouteDocs> routesDocs,
-            Response response) => new OpenApiOperation()
+            Response response,
+            OpenApiDocument openApiDocument) => new OpenApiOperation()
             {
-                Tags = GetTags(routesDocs),
+                Tags = GetTags(routesDocs, openApiDocument),
                 Summary = GetSummary(routesDocs),
                 Description = GetDescription(aggregateRoute, routesDocs),
                 Responses = OpenApiHelper.Responses(response),
@@ -224,9 +226,9 @@ namespace MMLib.SwaggerForOcelot.Aggregates
             return sb.ToString();
         }
 
-        private static ISet<OpenApiTagReference> GetTags(IEnumerable<RouteDocs> route)
+        private static ISet<OpenApiTagReference> GetTags(IEnumerable<RouteDocs> route, OpenApiDocument openApiDocument)
             => new List<OpenApiTagReference>() {
-                new OpenApiTagReference(RoutesToString(route))
+                new OpenApiTagReference(RoutesToString(route), openApiDocument)
             }.ToHashSet();
 
         private static string RoutesToString(IEnumerable<RouteDocs> route, string separator = "-")

--- a/src/MMLib.SwaggerForOcelot/Aggregates/AggregatesDocumentFilter.cs
+++ b/src/MMLib.SwaggerForOcelot/Aggregates/AggregatesDocumentFilter.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using Swashbuckle.AspNetCore.SwaggerGen;
-using Microsoft.OpenApi.Models;
+﻿using Microsoft.Extensions.Options;
+using Microsoft.OpenApi;
 using MMLib.SwaggerForOcelot.Configuration;
-using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Collections.Generic;
 
 namespace MMLib.SwaggerForOcelot.Aggregates
 {

--- a/src/MMLib.SwaggerForOcelot/Aggregates/IAggregateRouteDocumentationGenerator.cs
+++ b/src/MMLib.SwaggerForOcelot/Aggregates/IAggregateRouteDocumentationGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using Microsoft.OpenApi;
 
 namespace MMLib.SwaggerForOcelot.Aggregates
 {

--- a/src/MMLib.SwaggerForOcelot/Aggregates/RouteDocs.cs
+++ b/src/MMLib.SwaggerForOcelot/Aggregates/RouteDocs.cs
@@ -1,5 +1,5 @@
 ﻿using Kros.Extensions;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;

--- a/src/MMLib.SwaggerForOcelot/Configuration/OcelotGatewayItSelfSwaggerGenOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/OcelotGatewayItSelfSwaggerGenOptions.cs
@@ -89,7 +89,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
         {
             SecurityDefinitionActions.Add((s) =>
             {
-                s.AddSecurityRequirement((f) => openApiSecurityRequirement);
+                s.AddSecurityRequirement((_) => openApiSecurityRequirement);
             });
         }
     }

--- a/src/MMLib.SwaggerForOcelot/Configuration/OcelotGatewayItSelfSwaggerGenOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/OcelotGatewayItSelfSwaggerGenOptions.cs
@@ -1,8 +1,8 @@
-﻿using Swashbuckle.AspNetCore.SwaggerGen;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
 
 namespace MMLib.SwaggerForOcelot.Configuration
 {
@@ -89,7 +89,7 @@ namespace MMLib.SwaggerForOcelot.Configuration
         {
             SecurityDefinitionActions.Add((s) =>
             {
-                s.AddSecurityRequirement(openApiSecurityRequirement);
+                s.AddSecurityRequirement((f) => openApiSecurityRequirement);
             });
         }
     }

--- a/src/MMLib.SwaggerForOcelot/Configuration/OcelotSwaggerGenOptions.cs
+++ b/src/MMLib.SwaggerForOcelot/Configuration/OcelotSwaggerGenOptions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using Microsoft.OpenApi;
 using MMLib.SwaggerForOcelot.Aggregates;
 using System;
 using System.Collections.Generic;

--- a/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MMLib.SwaggerForOcelot/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.OpenApi;
+using MMLib.SwaggerForOcelot.Aggregates;
 using MMLib.SwaggerForOcelot.Configuration;
+using MMLib.SwaggerForOcelot.Middleware;
+using MMLib.SwaggerForOcelot.Repositories;
 using MMLib.SwaggerForOcelot.ServiceDiscovery;
 using MMLib.SwaggerForOcelot.Transformation;
-using System.Collections.Generic;
-using MMLib.SwaggerForOcelot.Middleware;
-using System;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using Microsoft.OpenApi.Models;
-using MMLib.SwaggerForOcelot.Repositories;
-using MMLib.SwaggerForOcelot.Aggregates;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 

--- a/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
+++ b/src/MMLib.SwaggerForOcelot/MMLib.SwaggerForOcelot.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <Version>9.0.0</Version>
         <Authors>Milan Martiniak</Authors>
         <Company>MMLib</Company>
@@ -24,11 +24,11 @@
         <None Include="icon.png" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Kros.Utils" Version="3.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.3" />
-        <PackageReference Include="Ocelot" Version="23.4.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.0" />
+        <PackageReference Include="Kros.Utils" Version="3.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+        <PackageReference Include="Ocelot" Version="24.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.0.1" />
     </ItemGroup>
     <ItemGroup>
         <None Include="../../README.md" Pack="true" PackagePath="\" />

--- a/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
+++ b/src/MMLib.SwaggerForOcelot/Middleware/SwaggerForOcelotMiddleware.cs
@@ -1,8 +1,7 @@
 ﻿using Kros.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Writers;
+using Microsoft.OpenApi;
 using MMLib.SwaggerForOcelot.Configuration;
 using MMLib.SwaggerForOcelot.Repositories;
 using MMLib.SwaggerForOcelot.ServiceDiscovery;

--- a/tests/MMLib.SwaggerForOcelot.BenchmarkTests/MMLib.SwaggerForOcelot.BenchmarkTests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.BenchmarkTests/MMLib.SwaggerForOcelot.BenchmarkTests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <PublishSingleFile>true</PublishSingleFile>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
 </Project>

--- a/tests/MMLib.SwaggerForOcelot.Tests/Aggregates/AggregateRouteDocumentationGeneratorShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Aggregates/AggregateRouteDocumentationGeneratorShould.cs
@@ -83,7 +83,6 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                         Summary = "Aggregation of routes: service1, service2",
                         Description = "Description from downstream services.<br /><br /><strong>service1:</strong><br />service 1<br /><br /><strong>service2:</strong><br />service 2",
                         Parameters = new List<IOpenApiParameter>()
-
                     });
             }
 

--- a/tests/MMLib.SwaggerForOcelot.Tests/Aggregates/AggregateRouteDocumentationGeneratorShould.cs
+++ b/tests/MMLib.SwaggerForOcelot.Tests/Aggregates/AggregateRouteDocumentationGeneratorShould.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using MMLib.SwaggerForOcelot.Aggregates;
 using MMLib.SwaggerForOcelot.Configuration;
 using Newtonsoft.Json.Linq;
@@ -82,6 +82,8 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     {
                         Summary = "Aggregation of routes: service1, service2",
                         Description = "Description from downstream services.<br /><br /><strong>service1:</strong><br />service 1<br /><br /><strong>service2:</strong><br />service 2",
+                        Parameters = new List<IOpenApiParameter>()
+
                     });
             }
 
@@ -99,7 +101,8 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     new OpenApiOperation()
                     {
                         Summary = "Aggregation of routes: service1, service2",
-                        Description = "custom aggregate description"
+                        Description = "custom aggregate description",
+                        Parameters = new List<IOpenApiParameter>()
                     });
             }
 
@@ -116,7 +119,8 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     new OpenApiOperation()
                     {
                         Summary = "Aggregation of routes: service1, service2",
-                        Description = "Description from downstream services.<br /><br /><strong>service1:</strong><br />service 1"
+                        Description = "Description from downstream services.<br /><br /><strong>service1:</strong><br />service 1",
+                        Parameters = new List<IOpenApiParameter>()
                     });
             }
 
@@ -133,7 +137,8 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     new OpenApiOperation()
                     {
                         Summary = "Aggregation of routes: service1, service2",
-                        Description = string.Empty
+                        Description = string.Empty,
+                        Parameters = new List<IOpenApiParameter>()
                     });
             }
 
@@ -152,7 +157,7 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     {
                         Summary = "Aggregation of routes: service1, service2",
                         Description = string.Empty,
-                        Parameters = new List<OpenApiParameter>() { CreateParameter("id") }
+                        Parameters = new List<IOpenApiParameter>() { CreateParameter("id") }
                     });
             }
 
@@ -171,7 +176,7 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     {
                         Summary = "Aggregation of routes: service1, service2",
                         Description = string.Empty,
-                        Parameters = new List<OpenApiParameter>() { CreateParameter("id"), CreateParameter("type") }
+                        Parameters = new List<IOpenApiParameter>() { CreateParameter("id"), CreateParameter("type") }
                     });
             }
 
@@ -194,7 +199,7 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     {
                         Summary = "Aggregation of routes: service1, service2",
                         Description = string.Empty,
-                        Parameters = new List<OpenApiParameter>() { CreateParameter("id"), CreateParameter("type") }
+                        Parameters = new List<IOpenApiParameter>() { CreateParameter("id"), CreateParameter("type") }
                     });
             }
 
@@ -216,7 +221,7 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     {
                         Summary = "Aggregation of routes: service1, service2",
                         Description = string.Empty,
-                        Parameters = new List<OpenApiParameter>() {
+                        Parameters = new List<IOpenApiParameter>() {
                             CreateParameter("id"), CreateParameter("q1", ParameterLocation.Query)
                         }
                     });
@@ -240,7 +245,7 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     {
                         Summary = "Aggregation of routes: service1, service2",
                         Description = string.Empty,
-                        Parameters = new List<OpenApiParameter>() {
+                        Parameters = new List<IOpenApiParameter>() {
                             CreateParameter("id"), CreateParameter("q1", ParameterLocation.Query)
                         }
                     });
@@ -266,7 +271,7 @@ namespace MMLib.SwaggerForOcelot.Tests.Aggregates
                     {
                         Summary = "Aggregation of routes: service1, service2",
                         Description = string.Empty,
-                        Parameters = new List<OpenApiParameter>() {
+                        Parameters = new List<IOpenApiParameter>() {
                             CreateParameter("id", description:"<strong>service1:</strong><br />User identifier<br /><br /><strong>service2:</strong><br />Identifier"),
                             CreateParameter("q1", ParameterLocation.Query)
                         }

--- a/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
+++ b/tests/MMLib.SwaggerForOcelot.Tests/MMLib.SwaggerForOcelot.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -64,14 +64,14 @@
     <EmbeddedResource Include="Tests\OpenApiWithHostOverriddenWhenUpstreamAndDownstreamPathsAreDifferent.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
-    <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="JsonDiffPatch.Net" Version="2.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
I have tried to update this project to be compatible with .net 10 and swashbuckle 10.
The unit tests are running and the ApiGateway-Demo shows all Apis and can execute the endpoints. 

Maybe you can take a look - I'm not 100% sure about the update to the Schema with OpenApiSchemaReference and the GetTags-Method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded projects and demos to .NET 10 and updated NuGet packages; CI workflows updated to use .NET 10.
* **Refactor**
  * Migrated to new OpenAPI type interfaces across the library, adjusting aggregate documentation surfaces and related signatures.
* **Tests**
  * Updated test dependencies and adapted tests to the new OpenAPI interface usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->